### PR TITLE
Reduce verbosity

### DIFF
--- a/ananicy.conf
+++ b/ananicy.conf
@@ -6,8 +6,8 @@ check_freq=15
 
 # Verbose msg: true/false
 cgroup_load=true
-type_load=true
-rule_load=true
+type_load=false
+rule_load=false
 
 apply_nice=true
 apply_ioclass=true


### PR DESCRIPTION
[ananicy.conf](https://github.com/CachyOS/ananicy-rules/blob/b12d39a57ed6f4044587188eec28a9dd8119d2a1/ananicy.conf) provided with the package spams journal. Setting `type_load` and `rule_load` to `false` solves this issue.