### PR TITLE
Add rules for gdm wayland and a few gnome services

### DIFF
--- a/00-default/DEs-and-WMs/gdm.rules
+++ b/00-default/DEs-and-WMs/gdm.rules
@@ -1,0 +1,3 @@
+# display manager
+{ "name" : "gdm", "type": "LowLatency_RT"}
+{ "name" : "gdm-wayland-session", "type": "LowLatency_RT"}

--- a/00-default/DEs-and-WMs/gnome.rules
+++ b/00-default/DEs-and-WMs/gnome.rules
@@ -1,2 +1,11 @@
 # http://live.gnome.org/ThumbnailerSpec 
 { "name": "tumblerd", "type": "TODO" }
+
+# Used for password management - https://wiki.archlinux.org/title/GNOME/Keyring
+{ "name" : "gnome-keyring-daemon", "type": "Service"}
+
+# Used for pam/gdm-password
+{ "name" : "gdm-session-worker", "type": "Service"}
+
+# polkit-gnome
+{ "name" : "polkit-gnome-authentication-agent-1", "type": "Service"}


### PR DESCRIPTION
I was getting this, seeing if it helps:
```
Jan 09 18:07:06 kit kernel: sched: RT throttling activated
Jan 09 18:07:04 kit /usr/lib/gdm-wayland-session[1595]: 00:55:10.276 [ERROR] [wlr] [xwayland/selection/incoming.c:466] convert selection failed
Jan 09 18:07:04 kit /usr/lib/gdm-wayland-session[1595]: 00:55:10.276 [ERROR] [wlr] [xwayland/selection/incoming.c:466] convert selection failed
Jan 09 18:07:04 kit /usr/lib/gdm-wayland-session[1595]: 00:55:10.276 [ERROR] [wlr] [xwayland/selection/incoming.c:466] convert selection failed
Jan 09 18:07:04 kit /usr/lib/gdm-wayland-session[1595]: 00:55:10.276 [ERROR] [wlr] [xwayland/selection/incoming.c:466] convert selection failed
Jan 09 18:07:04 kit /usr/lib/gdm-wayland-session[1595]: 00:55:10.276 [ERROR] [wlr] [xwayland/selection/incoming.c:466] convert selection failed
```