### PR TITLE
Fixed the cp2077 rules and Add trackmania Rule

### DIFF
--- a/00-default/games/cp2077.rules
+++ b/00-default/games/cp2077.rules
@@ -1,2 +1,3 @@
 # https://store.steampowered.com/app/1091500/Cyberpunk 2077/
 { "name": "Cyberpunk 2077.exe", "type": "Game"}
+{ "name": "Redprelauncher", "type": "game-launcher"}

--- a/00-default/games/trackmania.rules
+++ b/00-default/games/trackmania.rules
@@ -1,0 +1,2 @@
+# https://store.steampowered.com/app/2225070/Trackmania/
+{ "name": "Trackmania.exe", "type": "Game" }


### PR DESCRIPTION
Hello, in this pull i fixed the cp2077.rules with adding the redprelauncher : `{ "name": "Redprelauncher", "type": "game-launcher"}` and i create the new rule for the free game trackmania exit too on steam.

Best Regards,
NextWorks