### PR TITLE
Create dragonball.rules

### DIFF
--- a/00-default/games/dragonball.rules
+++ b/00-default/games/dragonball.rules
@@ -1,0 +1,7 @@
+# https://store.steampowered.com/app/454650/DRAGON_BALL_XENOVERSE_2/
+{ "name": "dbxv2.exe", "type": "Game" }
+
+# https://store.steampowered.com/app/851850/DRAGON_BALL_Z_KAKAROT/
+{ "name": "AT-Win64-Shipping.exe", "type": "Game" }
+{ "name": "AT.exe", "type": "Game" }
+# AT.exe is amusingly also shared with https://store.steampowered.com/app/331920/Airline_Tycoon_Deluxe/

--- a/00-default/games/dragonball.rules
+++ b/00-default/games/dragonball.rules
@@ -1,5 +1,5 @@
 # https://store.steampowered.com/app/454650/DRAGON_BALL_XENOVERSE_2/
-{ "name": "dbxv2.exe", "type": "Game" }
+{ "name": "DBXV2.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/851850/DRAGON_BALL_Z_KAKAROT/
 { "name": "AT-Win64-Shipping.exe", "type": "Game" }


### PR DESCRIPTION
Includes rules for DRAGON BALL XENOVERSE 2 and Dragon Ball Z: KAKAROT
Also includes a rule for Airline Tycoon Deluxe as a by-product (It shares its executable name with KAKAROT)