### PR TITLE
Works around https://github.com/ValveSoftware/gamescope/issues/107

### DIFF
--- a/00-default/games/gamescope.rules
+++ b/00-default/games/gamescope.rules
@@ -1,0 +1,1 @@
+{"name": "gamescope", "nice": -20}

--- a/00-default/games/gamescope.rules
+++ b/00-default/games/gamescope.rules
@@ -1,1 +1,1 @@
-{"name": "gamescope", "nice": -20}
+{"name": "gamescope", "type": "Game", "nice": -20}


### PR DESCRIPTION
I set it as type game since that seemed the most appropriate.
This sets gamescopes nice level properly while not stopping the steam overlay from functioning