### PR TITLE
Add vesktop(alternative discord app) to chats.rules

### DIFF
--- a/00-default/Chats/chats.rules
+++ b/00-default/Chats/chats.rules
@@ -20,6 +20,7 @@
 { "name": "DiscordPTB", "type": "Chat" }
 { "name": "webcord", "type": "Chat" }
 { "name": "armcord", "type": "Chat" }
+{ "name": "vesktop.bin", "type": "Chat" }
 
 # https://hexchat.github.io
 { "name": "hexchat", "type": "Chat" }


### PR DESCRIPTION
adds a rule for vesktop(custom discord client with vencord)