### PR TITLE
Added rules for hyprland, sway, waybar, kitty and nix

### DIFF
--- a/00-default/DEs-and-WMs/hyprland.rules
+++ b/00-default/DEs-and-WMs/hyprland.rules
@@ -1,2 +1,9 @@
 # https://github.com/hyprwm/Hyprland
 { "name": "Hyprland", "type": "LowLatency_RT" }
+{ "name": ".Hyprland", "type": "LowLatency_RT" }
+{ "name": ".Hyprland-wrapp", "type": "LowLatency_RT" }
+{ "name": ".Hyprland-wrapped", "type": "LowLatency_RT" }
+
+# https://github.com/hyprland-community/pyprland
+{ "name": "pypr", "type": "Image-View" }
+{ "name": ".pypr-wrapped", "type": "Image-View" }

--- a/00-default/DEs-and-WMs/sway.rules
+++ b/00-default/DEs-and-WMs/sway.rules
@@ -1,2 +1,15 @@
 # https://swaywm.org/
 { "name": "sway", "type": "LowLatency_RT" }
+{ "name": ".sway-wrapped", "type": "LowLatency_RT" }
+
+# Sway notification daemon
+# https://github.com/ErikReider/SwayNotificationCenter
+{ "name": "swaync", "type": "Service" }
+{ "name": ".swaync-wrapped", "type": "Service" }
+{ "name": "swaync-client", "type": "Service" }
+{ "name": ".swaync-client-", "type": "Service" }
+
+
+# Sway idle daemon
+# https://github.com/swaywm/swayidle
+{ "name": "swayidle", "type": "Service" }

--- a/00-default/Terminals/terminal.rules
+++ b/00-default/Terminals/terminal.rules
@@ -9,6 +9,7 @@
 
 # kitty: https://sw.kovidgoyal.net/kitty/
 { "name": "kitty", "type": "Doc-View" }
+{ "name": ".kitty-wrapped", "type": "Doc-View" }
 
 # hyper
 { "name": "hyper", "type": "Doc-View" }

--- a/00-default/nix.rules
+++ b/00-default/nix.rules
@@ -3,3 +3,12 @@
 { "name": "nix", "type": "BG_CPUIO" }
 { "name": "nix-daemon", "type": "BG_CPUIO" }
 { "name": "nix-store", "type": "BG_CPUIO" }
+
+# https://github.com/maralorn/nix-output-monitor
+{ "name": "nom", "type": "BG_CPUIO" }
+
+# Nix language LSP
+# https://github.com/nix-community/nixd
+{ "name": "nixd", "type": "BG_CPUIO" }
+# https://github.com/oxalica/nil
+{ "name": "nil", "type": "BG_CPUIO" }

--- a/00-default/waybar.rules
+++ b/00-default/waybar.rules
@@ -1,2 +1,3 @@
 # https://github.com/Alexays/Waybar
 { "name": "waybar", "type": "LowLatency_RT" }
+{ "name": ".waybar-wrapped", "type": "LowLatency_RT" }


### PR DESCRIPTION
This PR mainly adds the equivalent PNAME of already added programs in NixOS.
- `+ hyprland-wrapped`
- `+ sway-wrapped`
- `+ waybar-wrapped`
- `+ kitty-wrapped`

Without these, the programs mentioned lag, when in high system load.

In addition, it also adds
- swaync - Sway notification daemon
- swayidle - Sway idle daemon
- nix lsp rules like nixd and nil
-  nom rules, equivalent of nix commands

along with their NixOS equivalent PNAMEs.

Since both [Chaotic-Nyx](https://github.com/chaotic-cx/nyx) and Nixpkgs provide ananicy-cpp-rules cachyos as a package, I am compelled to add the NixOS equivalent rules.