### PR TITLE
Added rules for xdg, gvfs, wl-clipboard and more...

### DIFF
--- a/00-default/Audio-Video/playerctl.rules
+++ b/00-default/Audio-Video/playerctl.rules
@@ -1,0 +1,4 @@
+# Daemon for controlling music and video players
+# https://github.com/altdesktop/playerctl/issues/161
+
+{ "name": "playerctld", "type": "Player-Video" }

--- a/00-default/Browsers/browsers.rules
+++ b/00-default/Browsers/browsers.rules
@@ -13,6 +13,7 @@
 { "name": "google-chrome-dev", "type": "Doc-View" }
 { "name": "google-chrome-unstable", "type": "Doc-View" }
 { "name": "nacl_helper", "type": "Doc-View" }
+{ "name": "chrome_crashpad_handler", "type": "BG_CPUIO" }
 
 # Chromium - https://www.chromium.org/
 { "name": "chromium", "type": "Doc-View" }

--- a/00-default/Chats/chats.rules
+++ b/00-default/Chats/chats.rules
@@ -12,9 +12,13 @@
 { "name": "telegram-desktop", "type": "Chat" }
 { "name": "telegram-desktop.bin", "type": "Chat" }
 { "name": "telegram", "type": "Chat" }
+{ "name": ".telegram-deskt", "type": "Chat" }
+{ "name": ".telegram-desktop", "type": "Chat" }
 
 # Discord: https://discord.com/
 { "name": "Discord", "type": "Chat" }
+{ "name": ".Discord-wrappe", "type": "Chat" }
+{ "name": ".Discord-wrapped", "type": "Chat" }
 { "name": "DiscordCanary", "type": "Chat" }
 { "name": "DiscordDevelopment", "type": "Chat" }
 { "name": "DiscordPTB", "type": "Chat" }
@@ -43,6 +47,7 @@
 
 # https://www.mozilla.org/en-US/thunderbird/
 { "name": "thunderbird", "type": "Chat" }
+{ "name": ".thunderbird-wrapped", "type": "Chat" }
 
 # Franz and its forks: https://meetfranz.com/
 { "name": "ferdi", "type": "Chat" }

--- a/00-default/DEs-and-WMs/gnome.rules
+++ b/00-default/DEs-and-WMs/gnome.rules
@@ -3,6 +3,7 @@
 
 # Used for password management - https://wiki.archlinux.org/title/GNOME/Keyring
 { "name": "gnome-keyring-daemon", "type": "Service" }
+{ "name": ".gnome-keyring-", "type": "Service" }
 
 # Used for pam/gdm-password
 { "name": "gdm-session-worker", "type": "Service" }

--- a/00-default/Services/dbus.rules
+++ b/00-default/Services/dbus.rules
@@ -1,3 +1,5 @@
 # D-Bus is a message bus system that provides an easy way for inter-process communication.
 # https://wiki.archlinux.org/title/D-Bus and https://dbus.freedesktop.org/doc/dbus-daemon.1.html
 { "name": "dbus-daemon", "type": "Service" }
+{ "name": "dbus-broker", "type": "Service" }
+{ "name": "dbus-broker-launch", "type": "Service" }

--- a/00-default/Services/gvfs.rules
+++ b/00-default/Services/gvfs.rules
@@ -1,0 +1,27 @@
+# https://gitlab.gnome.org/GNOME/gvfs
+# pnames started with `.` are NixOS specific
+{ "name": "gvfsd", "type": "Service" }
+{ "name": ".gvfsd-wrapped", "type": "Service" }
+
+{ "name": "gvfsd-metadata", "type": "Service" }
+
+{ "name": "gvfsd-fuse", "type": "Service" }
+{ "name": ".gvfsd-fuse-wra", "type": "Service" }
+
+{ "name": "gvfsd-http", "type": "Service" }
+{ "name": ".gvfsd-http-wra", "type": "Service" }
+
+{ "name": "gvfs-afc-volume-monitor", "type": "Service" }
+{ "name": ".gvfs-afc-volum", "type": "Service" }
+
+{ "name": "gvfs-gphoto2-volume-monitor", "type": "Service" }
+{ "name": ".gvfs-gphoto2-v", "type": "Service" }
+
+{ "name": "gvfs-goa-volume-monitor", "type": "Service" }
+{ "name": ".gvfs-goa-volum", "type": "Service" }
+
+{ "name": "gvfs-mtp-volume-monitor", "type": "Service" }
+{ "name": ".gvfs-mtp-volum", "type": "Service" }
+
+{ "name": "gvfs-udisks2-volume-monitor", "type": "Service" }
+{ "name": ".gvfs-udisks2-v", "type": "Service" }

--- a/00-default/Services/misc-services.rules
+++ b/00-default/Services/misc-services.rules
@@ -1,0 +1,8 @@
+{ "name": "devmon", "type": "Service" }
+{ "name": "udevil", "type": "Service" }
+
+{ "name": "dconf-service", "type": "Service" }
+
+{ "name": "gpg", "type": "Service" }
+{ "name": "gpg-agent", "type": "Service" }
+{ "name": "scdaemon", "type": "Service" }

--- a/00-default/Services/xdg.rules
+++ b/00-default/Services/xdg.rules
@@ -1,0 +1,17 @@
+# https://flatpak.github.io/xdg-desktop-portal/
+{ "name": "xdg-desktop-portal", "type": "Service" }
+{ "name": "xdg-desktop-portal-gtk", "type": "Service" }
+{ "name": "xdg-desktop-portal-gnome", "type": "Service" }
+{ "name": "xdg-desktop-portal-hyprland", "type": "Service" }
+{ "name": "xdg-desktop-portal-kde", "type": "Service" }
+{ "name": "xdg-desktop-portal-lxqt", "type": "Service" }
+{ "name": "xdg-desktop-portal-shana", "type": "Service" }
+{ "name": "xdg-desktop-portal-wlr", "type": "Service" }
+{ "name": "xdg-desktop-portal-xapp", "type": "Service" }
+
+{ "name": "xdg-document-portal", "type": "Service" }
+{ "name": "xdg-permission-store", "type": "Service" }
+
+{ "name": ".xdg-desktop-po", "type": "Service" }
+{ "name": ".xdg-document-p", "type": "Service" }
+{ "name": ".xdg-permission", "type": "Service" }

--- a/00-default/tools/wl-clipboard.rules
+++ b/00-default/tools/wl-clipboard.rules
@@ -1,0 +1,3 @@
+# https://github.com/bugaevc/wl-clipboard
+{ "name": "wl-copy", "type": "Service" }
+{ "name": "wl-paste", "type": "Service" }


### PR DESCRIPTION
In summary this PR:
- Adds XDG portal service rules
- Adds GVFS service rules
- Adds wl-clipboard rules
- Adds miscellaneous services like dconf, devmon, udisks, gpg, playerctld
- Adds NixOS equivalent process names for
  + Discord
  + Gnome Keyring
  + Telegram
  + Thunderbird

+1 Also imposes `BG_CPUIO` rule on `chrome-crashpad-handler`.