### PR TITLE
remove native terraria from wine_proton.rules since it belongs to steam-native.rules

### DIFF
--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -1170,7 +1170,6 @@
 
 # https://store.steampowered.com/app/105600/Terraria/
 { "name": "Terraria", "type": "Game" }
-{ "name": "Terraria.bin.x86_64", "type": "Game" }
 
 # https://store.steampowered.com/app/211600/Thief_Gold/
 # https://www.ttlg.com/forums/showthread.php?t=134733


### PR DESCRIPTION
this commit removes the rule for "Terraria.bin.x86_64" in wine_proton.rules since it's the file for the native game and not the wine one(the rule is already present on steam-native.rules)