### PR TITLE
Add Owlcat's Pathfinder games

### DIFF
--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -882,6 +882,12 @@
 { "name": "PathOfExile_x64.exe", "type": "Game" }
 { "name": "PathOfExile.exe", "type": "Game" }
 
+# Pathfinder: Kingmaker https://store.steampowered.com/app/640820
+{ "name": "Kingmaker.exe", "type": "Game" }
+
+# Pathfinder: Wrath of the Righteous https://store.steampowered.com/app/1184370
+{ "name": "Wrath.exe", "type": "Game" }
+
 # Pro Evolution Soccer 2013 
 { "name": "pes2013.exe", "type": "Game" }
 


### PR DESCRIPTION
Kingmaker has a Linux version but from what I could tell looking at SteamDB it runs the same executable. It is generally advised to run the Proton version however.