### PR TITLE
Update wine_proton.rules

### DIFF
--- a/00-default/DEs-and-WMs/gnome.rules
+++ b/00-default/DEs-and-WMs/gnome.rules
@@ -50,3 +50,30 @@
 
 # gnome-control-center-search-provider
 { "name": "gnome-control-center-search-provider", "type": "Service" }
+
+# gsd-printer
+{ "name": "gsd-printer", "type": "Service" }
+
+# gsd-wacom
+{ "name": "gsd-wacom", "type": "Service" }
+
+# gsd-usb-protection
+{ "name": "gsd-usb-protection", "type": "Service" }
+
+# gsd-smartcard
+{ "name": "gsd-smartcard", "type": "Service" }
+
+# gsd-sharing
+{ "name": "gsd-sharing", "type": "Service" }
+
+# gsd-rfkill
+{ "name": "gsd-rfkill", "type": "Service" }
+
+# gsd-print-notification
+{ "name": "gsd-print-notifications", "type": "Service" }
+
+# gsd-color
+{ "name": "gsd-color", "type": "Service" }
+
+# gsd-a11y-settings
+{ "name": "gsd-a11y-settings", "type": "Service" }

--- a/00-default/DEs-and-WMs/gnome.rules
+++ b/00-default/DEs-and-WMs/gnome.rules
@@ -77,3 +77,9 @@
 
 # gsd-a11y-settings
 { "name": "gsd-a11y-settings", "type": "Service" }
+
+# goa-daemon
+{ "name": "goa-daemon", "type": "Service" }
+
+# goa-identity-service
+{ "name": "goa-identity-service", "type": "Service" }

--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -1116,7 +1116,13 @@
 
 # The Finals https://store.steampowered.com/app/2073850/THE_FINALS/
 { "name": "Discovery.exe", "type": "Game" }
+{ "name": "start_protected_game.exe", "type": "Game" }
+{ "name": "EasyAntiCheat_EOS_Setup.exe", "type": "Game" }
+{ "name": "UEPrereqSetup_x64.exe", "type": "Game" }
+{ "name": "CrashReportClient.exe", "type": "BG_CPUIO" }
 { "name": "crashpad_handler.exe", "type": "BG_CPUIO" }
+{ "name": "CrGpuMain.exe", "type": "BG_CPUIO" }
+{ "name": "CrUtilityMain.exe", "type": "BG_CPUIO" }
 
 # https://store.steampowered.com/agecheck/app/242760/The_Forest/
 { "name": "TheForest.exe", "type": "Game" }


### PR DESCRIPTION
Mapping all The Finals executables.

The Finals rely on EpicWebHelper.exe with CrGpuMain.exe and CrUtilityMain.exe.

Used for Chrome GPU accelerated operations etc.