### PR TITLE
Farlight 84 rule

### DIFF
--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -455,6 +455,10 @@
 # https://store.steampowered.com/app/204030/Fable__The_Lost_Chapters
 { "name": "Fable.exe", "type": "Game" }
 
+# https://store.steampowered.com/app/1928420/Farlight_84/
+{ "name": "SolarlandClient-Win64-Shipping.exe", "type": "Game" }
+{ "name": "SolarlandClient.exe", "type": "Game" }
+
 # https://store.steampowered.com/app/38400/Fallout_A_Post_Nuclear_Role_Playing_Game/
 { "name": "falloutw.exe", "type": "Game" }
 


### PR DESCRIPTION
Adds rules for farlight 84, this time with both SolarlandClient.exe and SolarlandClient-Win64-Shipping.exe. 
However, I don't know if both should be included, existing rules for some Unreal Engine games like Atomic Heart seem to include both, while others like Grounded include only the *-Win64-Shipping.exe. Also, only the *-Win64-Shipping.exe seems to appear on the proccess monitor