### PR TITLE
Fix: suyu process name incorrectly spelled as "suzu"

### DIFF
--- a/00-default/games/emulators.rules
+++ b/00-default/games/emulators.rules
@@ -13,7 +13,7 @@
 { "name": "cen64-qt", "type": "Game" }
 
 # A familiar, open source, and powerful N******* Switch emulator: https://suyu.dev/
-{ "name": "suzu", "type": "Game" }
+{ "name": "suyu", "type": "Game" }
 
 # Yuzu Emulator for Switch games: https://yuzu-emu.org/
 { "name": "yuzu", "type": "Game" }


### PR DESCRIPTION
This small PR just fixes the misspelled name for suyu game emulator.