### PR TITLE
Update terminal.rules - add ptyxis

### DIFF
--- a/00-default/Terminals/terminal.rules
+++ b/00-default/Terminals/terminal.rules
@@ -35,3 +35,7 @@
 
 # ghostty
 { "name": "ghostty", "type": "Doc-View" }
+
+# ptyxis
+{ "name": "ptyxis", "type": "Doc-View" }
+{ "name": "ptyxis-agent", "type": "Doc-View" }


### PR DESCRIPTION
ptyxis terminal is default in Fedora 41 now