### PR TITLE
Remove NixOS-specific rules

### DIFF
--- a/00-default/Chats/chats.rules
+++ b/00-default/Chats/chats.rules
@@ -18,7 +18,6 @@
 # Discord: https://discord.com/
 { "name": "Discord", "type": "Chat" }
 { "name": ".Discord-wrappe", "type": "Chat" }
-{ "name": ".Discord-wrapped", "type": "Chat" }
 { "name": "DiscordCanary", "type": "Chat" }
 { "name": "DiscordDevelopment", "type": "Chat" }
 { "name": "DiscordPTB", "type": "Chat" }
@@ -51,7 +50,6 @@
 
 # https://www.mozilla.org/en-US/thunderbird/
 { "name": "thunderbird", "type": "Chat" }
-{ "name": ".thunderbird-wrapped", "type": "Chat" }
 
 # https://github.com/Betterbird/thunderbird-patches
 { "name": "betterbird", "type": "Chat" }

--- a/00-default/DEs-and-WMs/hyprland.rules
+++ b/00-default/DEs-and-WMs/hyprland.rules
@@ -2,11 +2,9 @@
 { "name": "Hyprland", "type": "LowLatency_RT" }
 { "name": ".Hyprland", "type": "LowLatency_RT" }
 { "name": ".Hyprland-wrapp", "type": "LowLatency_RT" }
-{ "name": ".Hyprland-wrapped", "type": "LowLatency_RT" }
 
 # https://github.com/hyprland-community/pyprland
 { "name": "pypr", "type": "Image-View" }
-{ "name": ".pypr-wrapped", "type": "Image-View" }
 
 { "name": "hyprpaper", "type": "Service" }
 { "name": "hypridle", "type": "Service" }

--- a/00-default/DEs-and-WMs/sway.rules
+++ b/00-default/DEs-and-WMs/sway.rules
@@ -1,11 +1,9 @@
 # https://swaywm.org/
 { "name": "sway", "type": "LowLatency_RT" }
-{ "name": ".sway-wrapped", "type": "LowLatency_RT" }
 
 # Sway notification daemon
 # https://github.com/ErikReider/SwayNotificationCenter
 { "name": "swaync", "type": "Service" }
-{ "name": ".swaync-wrapped", "type": "Service" }
 { "name": "swaync-client", "type": "Service" }
 { "name": ".swaync-client-", "type": "Service" }
 

--- a/00-default/DEs-and-WMs/waybar.rules
+++ b/00-default/DEs-and-WMs/waybar.rules
@@ -1,3 +1,2 @@
 # https://github.com/Alexays/waybar
 { "name": "waybar", "type": "LowLatency_RT" }
-{ "name": ".waybar-wrapped", "type": "LowLatency_RT" }

--- a/00-default/Services/gvfs.rules
+++ b/00-default/Services/gvfs.rules
@@ -1,40 +1,14 @@
 # https://gitlab.gnome.org/GNOME/gvfs
-# pnames started with `.` are NixOS specific
 { "name": "gvfsd", "type": "Service" }
-{ "name": ".gvfsd-wrapped", "type": "Service" }
-
 { "name": "gvfsd-metadata", "type": "Service" }
-{ "name": ".gvfsd-metadata", "type": "Service" }
-
 { "name": "gvfsd-fuse", "type": "Service" }
-{ "name": ".gvfsd-fuse-wra", "type": "Service" }
-
 { "name": "gvfsd-http", "type": "Service" }
-{ "name": ".gvfsd-http-wra", "type": "Service" }
-
 { "name": "gvfsd-dnssd", "type": "Service" }
-{ "name": ".gvfsd-dnssd-wr", "type": "Service" }
-
 { "name": "gvfsd-network", "type": "Service" }
-{ "name": ".gvfsd-network-", "type": "Service" }
-
 { "name": "gvfsd-recent", "type": "Service" }
-{ "name": ".gvfsd-recent-w", "type": "Service" }
-
 { "name": "gvfsd-trash", "type": "Service" }
-{ "name": ".gvfsd-trash-wr", "type": "Service" }
-
 { "name": "gvfs-afc-volume-monitor", "type": "Service" }
-{ "name": ".gvfs-afc-volum", "type": "Service" }
-
 { "name": "gvfs-gphoto2-volume-monitor", "type": "Service" }
-{ "name": ".gvfs-gphoto2-v", "type": "Service" }
-
 { "name": "gvfs-goa-volume-monitor", "type": "Service" }
-{ "name": ".gvfs-goa-volum", "type": "Service" }
-
 { "name": "gvfs-mtp-volume-monitor", "type": "Service" }
-{ "name": ".gvfs-mtp-volum", "type": "Service" }
-
 { "name": "gvfs-udisks2-volume-monitor", "type": "Service" }
-{ "name": ".gvfs-udisks2-v", "type": "Service" }

--- a/00-default/Terminals/terminal.rules
+++ b/00-default/Terminals/terminal.rules
@@ -9,7 +9,6 @@
 
 # kitty: https://sw.kovidgoyal.net/kitty/
 { "name": "kitty", "type": "Doc-View" }
-{ "name": ".kitty-wrapped", "type": "Doc-View" }
 
 # hyper
 { "name": "hyper", "type": "Doc-View" }

--- a/00-default/nix.rules
+++ b/00-default/nix.rules
@@ -18,8 +18,6 @@
 
 # https://github.com/Mic92/nixpkgs-review
 { "name": "nixpkgs-review", "type": "BG_CPUIO" }
-{ "name": ".nixpkgs-review-wrapped", "type": "BG_CPUIO" }
 
 # https://github.com/viperML/nh
 { "name": "nh", "type": "BG_CPUIO" }
-{ "name": ".nh-wrapped", "type": "BG_CPUIO" }

--- a/00-default/widget-manager.rules
+++ b/00-default/widget-manager.rules
@@ -1,6 +1,5 @@
 # https://github.com/Aylur/ags
 { "name": "ags", "type": "Doc-View" }
-{ "name": ".ags-wrapped", "type": "Doc-View" }
 
 # https://github.com/davatorium/rofi
 { "name": "rofi", "type": "Doc-View" }


### PR DESCRIPTION
There's a patch applied to ananicy-cpp that automatically finds wrappers