### PR TITLE
Add OpenSCAD rules

### DIFF
--- a/00-default/openscad.rules
+++ b/00-default/openscad.rules
@@ -1,0 +1,2 @@
+# OpenSCAD: https://openscad.org/
+{ "name": "openscad", "type": "Heavy_CPU" }


### PR DESCRIPTION
OpenSCAD renders are a heavy CPU workload.