### PR TITLE
Add Missing "#" on Comment

### DIFF
--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -1401,7 +1401,7 @@
 { "name": "wrath-sdl.exe", "type": "Game" }
 { "name": "wrath.exe", "type": "Game" }
 
-https://store.steampowered.com/app/1911610/Windblown/
+# https://store.steampowered.com/app/1911610/Windblown/
 { "name": "Windblown.exe", "type": "Game" }
 
 ### X ###


### PR DESCRIPTION
Pretty straight-forward, seems like the “#” got lost somewhere, causing an error in `ananicy-cpp` when reading the rules.

Resolves: #176