### PR TITLE
gdm: Define service affinity

### DIFF
--- a/00-default/DEs-and-WMs/gdm.rules
+++ b/00-default/DEs-and-WMs/gdm.rules
@@ -1,10 +1,10 @@
 # display manager
-{ "name": "gdm3", "type": "LowLatency_RT" }
-{ "name": "gdm", "type": "LowLatency_RT" }
-{ "name": "gdm-wayland-session", "type": "LowLatency_RT" }
-{ "name": "gdm-session-worker", "type": "LowLatency_RT" }
+{ "name": "gdm3", "type": "Service" }
+{ "name": "gdm", "type": "Service" }
+{ "name": "gdm-wayland-session", "type": "Service" }
+{ "name": "gdm-session-worker", "type": "Service" }
 
 # gnome shell
-{ "name": "gnome-shell","type": "LowLatency_RT"}
-{ "name": "gnome-session-binary","type": "LowLatency_RT"}
-{ "name": "gnome-session-ctl","type": "LowLatency_RT"}
+{ "name": "gnome-shell","type": "Service"}
+{ "name": "gnome-session-binary","type": "Service"}
+{ "name": "gnome-session-ctl","type": "Service"}


### PR DESCRIPTION
Gnome has removing realtime from mutter
because of problems with gnome-shell and gc's time
as the same time rt has bring some problems in gnome sessions like crash, now gnome not has more realtime for mutter and all dependents like gnome shell and even kms thread is not more running in rt 