### PR TITLE
Add rule for Luanti (formerly Minetest)

### DIFF
--- a/00-default/games/luanti.rules
+++ b/00-default/games/luanti.rules
@@ -1,0 +1,2 @@
+# http://www.luanti.org/
+{ "name": "luanti", "type": "Game" }


### PR DESCRIPTION
The Minetest developers have renamed their game to Luanti, details in [this blog post](https://blog.luanti.org/2024/10/13/Introducing-Our-New-Name).

Therefore, I have added a new rule to support Luanti.
An example of Luanti's process:

```
ps -A | grep luanti
54034 ?         00:00:00 luanti
```

The rule for Minetest is still kept for those who still use the `minetest` command to run the game.