### PR TITLE
Expand rules for Zen Browser and Betterbird

### DIFF
--- a/00-default/Browsers/browsers.rules
+++ b/00-default/Browsers/browsers.rules
@@ -57,6 +57,7 @@
 
 # Zen: https://zen-browser.app
 { "name": "zen-bin", "type": "Doc-View" }
+{ "name": "zen", "type": "Doc-View" }
 
 # Floorp - https://floorp.app
 { "name": "floorp", "type": "Doc-View" }

--- a/00-default/Chats/chats.rules
+++ b/00-default/Chats/chats.rules
@@ -53,6 +53,7 @@
 
 # https://github.com/Betterbird/thunderbird-patches
 { "name": "betterbird", "type": "Chat" }
+{ "name": "betterbird-bin", "type": "Chat" }
 
 # Franz and its forks: https://meetfranz.com/
 { "name": "ferdi", "type": "Chat" }


### PR DESCRIPTION
The process names for Zen Browser and Betterbird installed via Flatpak are `zen` and `betterbird-bin`.

```text
$ ps -Ae | grep zen
30378 ?        00:43:50 zen
84370 ?        00:04:01 zen
```

```text
$ ps -Ae | grep betterbird
87265 ?        00:00:09 betterbird-bin
```