### PR TITLE
Get rid of the remainder of the NixOS rules

### DIFF
--- a/00-default/Chats/chats.rules
+++ b/00-default/Chats/chats.rules
@@ -12,12 +12,9 @@
 { "name": "telegram-desktop", "type": "Chat" }
 { "name": "telegram-desktop.bin", "type": "Chat" }
 { "name": "telegram", "type": "Chat" }
-{ "name": ".telegram-deskt", "type": "Chat" }
-{ "name": ".telegram-desktop", "type": "Chat" }
 
 # Discord: https://discord.com/
 { "name": "Discord", "type": "Chat" }
-{ "name": ".Discord-wrappe", "type": "Chat" }
 { "name": "DiscordCanary", "type": "Chat" }
 { "name": "DiscordDevelopment", "type": "Chat" }
 { "name": "DiscordPTB", "type": "Chat" }

--- a/00-default/DEs-and-WMs/gnome.rules
+++ b/00-default/DEs-and-WMs/gnome.rules
@@ -3,14 +3,12 @@
 
 # Used for password management - https://wiki.archlinux.org/title/GNOME/Keyring
 { "name": "gnome-keyring-daemon", "type": "Service" }
-{ "name": ".gnome-keyring-", "type": "Service" }
 
 # polkit-gnome
 { "name": "polkit-gnome-authentication-agent-1", "type": "Service" }
 
 # network-manager applet
 { "name": "nm-applet", "type": "Service" }
-{ "name": ".nm-applet-wrap", "type": "Service" }
 
 # gsd-datetime
 { "name": "gsd-datetime", "type": "Service" }

--- a/00-default/DEs-and-WMs/hyprland.rules
+++ b/00-default/DEs-and-WMs/hyprland.rules
@@ -1,7 +1,5 @@
 # https://github.com/hyprwm/Hyprland
 { "name": "Hyprland", "type": "LowLatency_RT" }
-{ "name": ".Hyprland", "type": "LowLatency_RT" }
-{ "name": ".Hyprland-wrapp", "type": "LowLatency_RT" }
 
 # https://github.com/hyprland-community/pyprland
 { "name": "pypr", "type": "Image-View" }

--- a/00-default/DEs-and-WMs/sway.rules
+++ b/00-default/DEs-and-WMs/sway.rules
@@ -5,7 +5,6 @@
 # https://github.com/ErikReider/SwayNotificationCenter
 { "name": "swaync", "type": "Service" }
 { "name": "swaync-client", "type": "Service" }
-{ "name": ".swaync-client-", "type": "Service" }
 
 
 # Sway idle daemon

--- a/00-default/Services/xdg.rules
+++ b/00-default/Services/xdg.rules
@@ -11,7 +11,3 @@
 
 { "name": "xdg-document-portal", "type": "Service" }
 { "name": "xdg-permission-store", "type": "Service" }
-
-{ "name": ".xdg-desktop-po", "type": "Service" }
-{ "name": ".xdg-document-p", "type": "Service" }
-{ "name": ".xdg-permission", "type": "Service" }

--- a/00-default/tools/system-monitoring.rules
+++ b/00-default/tools/system-monitoring.rules
@@ -9,7 +9,6 @@
 
 # GNOME System Monitor
 { "name": "gnome-system-monitor", "type": "Doc-View" }
-{ "name": ".gnome-system-m", "type": "Doc-View" }
 
 # https://gitlab.com/mission-center-devs/mission-center
 { "name": "missioncenter", "type": "Doc-View" }


### PR DESCRIPTION
There do not appear to be any double-wrapped variants

Entries were found using git grep ': "\.'