### PR TITLE
Add rules for Hollow Knight: Silksong (both native and Proton)

### DIFF
--- a/00-default/games/steam-native.rules
+++ b/00-default/games/steam-native.rules
@@ -194,6 +194,9 @@
 # https://store.steampowered.com/app/367520/Hollow_Knight/
 { "name": "hollow_knight.x86_64", "type": "Game" }
 
+# https://store.steampowered.com/app/1030300/Hollow_Knight_Silksong/
+{ "name": "Hollow Knight Silksong", "type": "Game" }
+
 # https://store.steampowered.com/app/2218750/Halls_of_Torment/
 { "name": "HallsOfTorment.x86_64", "type": "Game" }
 

--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -656,6 +656,9 @@
 # https://store.steampowered.com/app/367520/Hollow_Knight/
 { "name": "hollow_knight.exe", "type": "Game" }
 
+# https://store.steampowered.com/app/1030300/Hollow_Knight_Silksong/
+{ "name": "Hollow Knight S", "type": "Game" }
+
 # https://store.steampowered.com/app/2420510/HoloCure__Save_the_Fans/
 { "name": "HoloCure.exe", "type": "Game" }
 


### PR DESCRIPTION
The process names look a little strange at first glance but I did double check and verify that "Hollow Knight Silksong" and "Hollow Knight S" were the process names for the native version and the proton version respectively.