### PR TITLE
Create prismlauncher.rules

### DIFF
--- a/00-default/games/prismlauncher.rules
+++ b/00-default/games/prismlauncher.rules
@@ -1,0 +1,2 @@
+# Prism Launcher; Used to launch minecraft (https://github.com/PrismLauncher/PrismLauncher)
+{ "name": "prismlauncher", "type": "Game" }


### PR DESCRIPTION
Add support to prismlauncher – open source minecraft launcher. I don't know how to add minecraft alone because it is run by java. Ideally prism launcher should have "BG_CPUIO" type, but i don't know how can you split it from minecraft