### PR TITLE
fix yakuza exe names

### DIFF
--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -1704,28 +1704,28 @@
 ### Y ###
 
 # https://store.steampowered.com/app/638970/Yakuza_0/
-{ "name": "Yakzua0.exe", "type": "Game" }
+{ "name": "Yakuza0.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/1088712/Yakuza_3_Remastered/
-{ "name": "Yakzua3.exe", "type": "Game" }
+{ "name": "Yakuza3.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/1105500/Yakuza_4_Remastered/
-{ "name": "Yakzua4.exe", "type": "Game" }
+{ "name": "Yakuza4.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/1105510/Yakuza_5_Remastered/
-{ "name": "Yakzua5.exe", "type": "Game" }
+{ "name": "Yakuza5.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/1388590/Yakuza_6_The_Song_of_Life
-{ "name": "Yakzua6.exe", "type": "Game" }
+{ "name": "Yakuza6.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/1235140/Yakuza_Like_a_Dragon/
-{ "name": "YakzuaLikeADragon.exe", "type": "Game" }
+{ "name": "YakuzaLikeADragon.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/834530/Yakuza_Kiwami/
-{ "name": "YakzuaKiwami.exe", "type": "Game" }
+{ "name": "YakuzaKiwami.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/927380/Yakuza_Kiwami_2/
-{ "name": "YakzuaKiwami2.exe", "type": "Game" }
+{ "name": "YakuzaKiwami2.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/2163330/Yet_Another_Zombie_Survivors/
 { "name": "Yet Another Zombie Survivors.exe", "type": "Game" }


### PR DESCRIPTION
When I added the names of the Yakuza titles, I accidentally misspelled "Yakuza" as "Yakzua." This PR fixes that.