### PR TITLE
Added rules for protonvpn gtk client.

### DIFF
--- a/00-default/VPN/protonvpn.rules
+++ b/00-default/VPN/protonvpn.rules
@@ -1,0 +1,2 @@
+# ProtonVPN - GTK VPN client
+{ "name": "protonvpn-app", "type": "IN_DIFF" } 


### PR DESCRIPTION
Would `IN_DIFF` be the appropriate type for the gtk client that resides in the system tray or `BG_CPUIO`