### PR TITLE
waybar: un-prioritise

### DIFF
--- a/00-default/DEs-and-WMs/waybar.rules
+++ b/00-default/DEs-and-WMs/waybar.rules
@@ -1,2 +1,2 @@
 # https://github.com/Alexays/waybar
-{ "name": "waybar", "type": "LowLatency_RT" }
+{ "name": "waybar", "type": "Service" }


### PR DESCRIPTION
Reduce waybar priority from `LowLatency_RT` to `Service`. This might be undesirable for some users who have some CPU/IO-intensive workloads on the waybar. But I think for the majority of people, it is mostly low priority services on the bar which isn't demanding or requires high responsiveness/frequent updates.