### PR TITLE
wineserver: re-add rule

### DIFF
--- a/00-default/games/wineserver.rules
+++ b/00-default/games/wineserver.rules
@@ -1,0 +1,3 @@
+# Reschedule Wineserver for better performance
+# https://gitlab.winehq.org/wine/wine/-/wikis/Man-Pages/wineserver
+{ "name": "wineserver", "type": "LowLatency_RT" }


### PR DESCRIPTION
The `wineserver` rule was removed in #179, which honestly I didn't understand or agree with. According to its [manpage](https://gitlab.winehq.org/wine/wine/-/wikis/Man-Pages/wineserver),

> wineserver is a daemon process that provides to Wine roughly the same services that the Windows kernel provides on Windows.

From that description, I think it should have high priority, if not FIFO/RR.