### PR TITLE
browsers: qutebrowser, move QtWebEngineProcess

### DIFF
--- a/00-default/Audio-Video/qtwebengine.rules
+++ b/00-default/Audio-Video/qtwebengine.rules
@@ -1,2 +1,0 @@
-# Video player: https://doc.qt.io/qt-5.11/qtwebengine-index.html
-{ "name": "QtWebEngineProcess", "type": "Player-Video" }

--- a/00-default/Browsers/qtwebengine.rules
+++ b/00-default/Browsers/qtwebengine.rules
@@ -1,0 +1,3 @@
+# QuteWebEngine - https://doc.qt.io/qt-6/qtwebengine-index.html
+# used in, e.g., Qutebrower - https://qutebrowser.org/index.html
+{ "name": "QtWebEngineProcess", "type": "Doc-View" }


### PR DESCRIPTION
Moved `QtWebEngineProcess` to the Browsers (`Doc-View` type), as it is the main process in charge of doing things in qutebrowser. The browser itself is run as a python script.