### PR TITLE
Add Thorium as browser

### DIFF
--- a/00-default/Browsers/browsers.rules
+++ b/00-default/Browsers/browsers.rules
@@ -21,7 +21,6 @@
 # Thorium - https://thorium.rocks/
 { "name": "thorium", "type": "Doc-View" }
 { "name": "thorium-browser", "type": "Doc-View" }
-{ "name": "/opt/chromium.org/thorium/thorium", "type": "Doc-View" }
 
 # Cromite - https://github.com/uazo/cromite
 { "name": "cromite", "type": "Doc-View" }


### PR DESCRIPTION
This adds Thorium under the browser rules hereby giving it the same priority as other browsers.