### PR TITLE
Add rule for X4: Foundations

### DIFF
--- a/00-default/games/steam-native.rules
+++ b/00-default/games/steam-native.rules
@@ -544,6 +544,9 @@
 
 ### X ###
 
+# https://store.steampowered.com/app/392160/X4_Foundations/
+{ "name": "X4", "type": "Game" }
+
 # https://store.steampowered.com/app/268500/XCOM_2/
 { "name": "XCOM2", "type": "Game" }
 

--- a/00-default/games/x4.rules
+++ b/00-default/games/x4.rules
@@ -1,3 +1,0 @@
-# https://store.steampowered.com/app/392160/X4_Foundations/
-{ "name": "X4", "type": "Game" }
-


### PR DESCRIPTION
X4: Foundations uses `X4` as its process name on Linux.

This rule applies the `Game` profile to improve CPU scheduling and latency during gameplay.