### PR TITLE
Add Spellforce and ROUNDS

### DIFF
--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -1410,6 +1410,9 @@
 # https://store.steampowered.com/app/312520/Rain_World/
 { "name": "RainWorld.exe", "type": "Game" }
 
+# https://store.steampowered.com/app/1557740/ROUNDS/
+{ "name": "ROUNDS.exe", "type": "Game" }
+
 ### S ###
 
 # Shadow of the Tomb Raider
@@ -1488,6 +1491,9 @@
 
 # Sonic Racing: Crossworlds
 { "name": "SonicRacingCrossWorldsSteam.exe", "type": "Game" }
+
+# https://store.steampowered.com/app/39540/SpellForce__Platinum_Edition/
+{ "name": "SpellForce.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/1817070/Marvels_SpiderMan_Remastered/
 { "name": "Spider-Man.exe", "type": "Game" }


### PR DESCRIPTION
This PR adds two new Proton game rules for:

 - ROUNDS (https://store.steampowered.com/app/1557740/ROUNDS/)
 - Spellforce - Platinum edition (https://store.steampowered.com/app/39540/SpellForce__Platinum_Edition/)