### PR TITLE
Add Helium Browser

### DIFF
--- a/00-default/Browsers/browsers.rules
+++ b/00-default/Browsers/browsers.rules
@@ -21,6 +21,10 @@
 # Cromite - https://github.com/uazo/cromite
 { "name": "cromite", "type": "Doc-View" }
 
+# Helium - https://helium.computer/
+{ "name": "helium", "type": "Doc-View" }
+{ "name": "helium_crashpad_handler", "type": "BG_CPUIO" }
+
 # Opera - https://www.opera.com/
 { "name": "opera", "type": "Doc-View" }
 


### PR DESCRIPTION
https://helium.computer/

Since version 0.8.3.1 Helium renamed their binary from `chrome` to `helium`: https://github.com/imputnet/helium-linux/releases/tag/0.8.3.1