### PR TITLE
Delete java.rules

### DIFF
--- a/00-default/java.rules
+++ b/00-default/java.rules
@@ -1,2 +1,0 @@
-# JAVA: https://www.java.com/en/
-{ "name": "java", "type": "BG_CPUIO", "sched": "normal" }


### PR DESCRIPTION
This rule applies to all `java` processes including games such as Minecraft. Even though 31af490 appears to fix the crashes this is causing several players, it's still not great that these get put into `BG_CPUIO`.