### PR TITLE
Change `gamescope` type to 'LowLatency_RT' and move to 'DEs-and-WMs'

### DIFF
--- a/00-default/DEs-and-WMs/gamescope.rules
+++ b/00-default/DEs-and-WMs/gamescope.rules
@@ -1,0 +1,4 @@
+# gamescope - a microcompositor by Valve: https://github.com/ValveSoftware/gamescope
+{"name": "gamescope", "type": "LowLatency_RT"}
+{"name": "gamescope-wl", "type": "LowLatency_RT"}
+{"name": "gamescopereaper", "type": "LowLatency_RT"}

--- a/00-default/games/gamescope.rules
+++ b/00-default/games/gamescope.rules
@@ -1,1 +1,0 @@
-{"name": "gamescope", "type": "Game", "nice": -20}


### PR DESCRIPTION
Hi! This reasons for this change are as follows:

- Gamescope is not a game, but a microcompositor.
- Therefore it's folder should be inside `DEs-and-WMs` with other compositors.

**Fixes:** #208 