### PR TITLE
Add Buckshot Roulette to steam-native.rules

### DIFF
--- a/00-default/games/steam-native.rules
+++ b/00-default/games/steam-native.rules
@@ -49,6 +49,9 @@
 # https://store.steampowered.com/app/362890/Black_Mesa/
 { "name": "bms_linux", "type": "Game" }
 
+# https://store.steampowered.com/app/2835570/Buckshot_Roulette/
+{ "name": "Buckshot Roulette.x86_64", "type": "Game" }
+
 # https://store.steampowered.com/app/474210/BUTCHER/
 { "name": "Butcher", "type": "Game" }
 


### PR DESCRIPTION
Added Buckshot Roulette to steam-native.rules

Store Page
https://store.steampowered.com/app/2835570/Buckshot_Roulette/

Only nit is that this game is available through other sources (it was originally released on itchio) But it is currently on steam as its primary release source so I added it to the steam-native file as that seemed the most relevant. Will move to another file if required.