### PR TITLE
Fix Gunner HEAT typo

### DIFF
--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -731,7 +731,7 @@
 { "name": "Clash-Win64-Shipping.exe", "type": "Game" }
 
 # https://store.steampowered.com/app/1705180/Gunner_HEAT_PC/
-{ "name": "GHPC.exe", "type": "type": "Game"}
+{ "name": "GHPC.exe", "type": "Game"}
 
 # https://store.steampowered.com/app/400750/Call_to_Arms__Gates_of_Hell_Ostfront/
 { "name": "call_to_arms.exe", "type": "Game"}


### PR DESCRIPTION
Fixes this typo where the game Gunner HEAT contains `"type": ` twice in a row:
`{ "name": "GHPC.exe", "type": "type": "Game"}`

I think that this only affects this one entry. I just noticed a JSON parse error in the service journal.