### PR TITLE
Add crashhelper in `misc-services.rules`

### DIFF
--- a/00-default/Services/misc-services.rules
+++ b/00-default/Services/misc-services.rules
@@ -1,6 +1,8 @@
 # https://github.com/containers/bubblewrap
 { "name": "bwrap", "type": "Service" }
 
+{ "name": "crashhelper", "type": "BG_CPUIO" }
+
 { "name": "devmon", "type": "Service" }
 { "name": "fsnotifier", "type": "Service" }
 { "name": "udevil", "type": "Service" }


### PR DESCRIPTION
This PR adds a rule for crashhelper for the following reason:

- Before it inherited -12 niceness and the type of `LowLatency_RT` because it was launched by systemd. This made it a direct competitor to Xorg, etc.

I think that the type `BG_CPUIO` might not be correct for this, if it's not, then this can be promoted to the `Services` type. Though I don't think this process will be very active under normal use.

Thanks!