### PR TITLE
Added the remaining FNAF games and some Sonic games

### DIFF
--- a/00-default/games/wine_proton.rules
+++ b/00-default/games/wine_proton.rules
@@ -2888,6 +2888,44 @@
 # https://store.steampowered.com/app/474220/Soldat_2/
 { "name": "soldat2.exe", "type": "Game" }
 
+# Sonic Mania https://store.steampowered.com/app/584400/Sonic_Mania/
+{ "name": "SonicMania.exe", "type": "Game" }
+
+# Sonic Lost World https://store.steampowered.com/app/329440/Sonic_Lost_World/
+{ "name": "slw.exe", "type": "Game" }
+
+# Sonic Frontiers https://store.steampowered.com/app/1237320/Sonic_Frontiers/
+{ "name": "SonicFrontiers.exe", "type": "Game" }
+
+# Sonic Forces https://store.steampowered.com/app/637100/Sonic_Forces/
+{ "name": "Sonic Forces.exe", "type": "Game" }
+
+# Sonic Generations (Legacy) https://store.steampowered.com/app/71340/Sonic_Generations_Collection/
+{ "name": "SonicGenerations.exe", "type": "Game" }
+
+# Sonic Adventure DX https://store.steampowered.com/app/71250/Sonic_Adventure_DX/
+{ "name": "Sonic Adventure DX.exe", "type": "Game" }
+{ "name": "AppLauncher.exe", "type": "Game" }
+
+# Sonic Adventure 2 https://store.steampowered.com/app/213610/Sonic_Adventure_2/
+{ "name": "sonic2app.exe", "type": "Game" }
+{ "name": "Launcher.exe", "type": "Game" }
+
+# Sonic Origins https://store.steampowered.com/app/1794960/Sonic_Origins/
+{ "name": "SonicOrigins.exe", "type": "Game" }
+
+# Sonic Colors Ultimate https://store.steampowered.com/app/2055290/Sonic_Colors_Ultimate/
+{ "name": "SonicColorsUltimate.exe", "type": "Game" }
+
+# Sonic & All-Stars Racing Transformed Collection https://store.steampowered.com/app/212480/Sonic__AllStars_Racing_Transformed_Collection/
+{ "name": "Launcher.exe", "type": "Game" }
+{ "name": "ASN_App_PcDx9_Final.exe", "type": "Game" }
+
+# Sonic Rumble https://store.steampowered.com/app/2951690/Sonic_Rumble/
+{ "name": "GameLauncher.exe", "type": "Game" }
+{ "name": "SonicRumble.exe", "type": "Game" }
+{ "name": "ucldr_SonicRumble_ST_loader_x64.exe", "type": "Game" }
+
 # Sonic Racing: Crossworlds https://store.steampowered.com/app/2486820/Sonic_Racing_CrossWorlds/
 { "name": "SonicRacingCrossWorldsSteam.exe", "type": "Game" }
 


### PR DESCRIPTION
This PR adds the remaining FNAF games to the rules

- FNAF 2
- FNAF 3
- FNAF 4
- FNAF 5 Sister Location
- FNAF 6 Pizzeria Simulator
- Ultimate Custom Night (UCN)
- FNAF World
- FNAF Security Breach
- FNAF Secret of the Mimic

------
and also some Sonic games

- Sonic Mania
- Sonic Lost World
- Sonic Frontiers
- Sonic Forces
- Sonic Generations (Legacy)
- Sonic Adventure DX
- Sonic Adventure 2
- Sonic Origins
- Sonic Colors Ultimate
- Sonic & All-Stars Racing Transformed Collection
- Sonic Rumble