### PR TITLE
Add rules for python in `Development & Programming`

### DIFF
--- a/00-default/Development & Programming/python.rules
+++ b/00-default/Development & Programming/python.rules
@@ -1,0 +1,4 @@
+# python - https://www.python.org
+{ "name": "python3", "type": "IN_DIFF" }
+{ "name": "python2", "type": "IN_DIFF" }
+{ "name": "python", "type": "IN_DIFF" }


### PR DESCRIPTION
Hi!
I decided to python to the rules because:

- Before when python was launched, it would inherit -12 niceness, which makes it a direct competitor to Xorg etc.
- Programs like `lutris` inherited the niceness too, which is bad as if you launch a game you obviously want it to have more resources than the launcher itself.

I have reduced the type to `IN_DIFF` as it's a neutral value, if you think it should be slightly more aggressive, then please correct me.
Thanks!