### PR TITLE
fix mess and improve sort

### DIFF
--- a/00-default/Games/linux-native/linux-native_a.rules
+++ b/00-default/Games/linux-native/linux-native_a.rules
@@ -1,5 +1,9 @@
-### A ###
+# Add games in alphabetical order.
+# Add name of game next to the url.
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
+### A ###
 
 # AaaaaAAaaaAAAaaAAAAaAAAAA!!! for the Awesome https://store.steampowered.com/app/15560/AaaaaAAaaaAAAaaAAAAaAAAAA_for_the_Awesome/
 { "name": "Awesome.x86", "type": "Game" }
@@ -25,12 +29,6 @@
 
 # A Date with Death https://store.steampowered.com/app/2415010/A_Date_with_Death/
 { "name": "ADatewithDeath", "type": "Game" }
-
-# Add games in alphabetical order.
-
-
-# Add name of game next to the url.
-
 
 # AdVenture Capitalist https://store.steampowered.com/app/346900/AdVenture_Capitalist/
 { "name": "adventure-capitalist.x86_64", "type": "Game" }
@@ -198,10 +196,3 @@
 
 # Axis & Allies 1942 Online https://store.steampowered.com/app/898920/Axis__Allies_1942_Online/
 { "name": "AxisAndAllies1942Online", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/linux-native/linux-native_b.rules
+++ b/00-default/Games/linux-native/linux-native_b.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### B ###
-
 
 # Backpack Battles https://store.steampowered.com/app/2427700/Backpack_Battles/
 { "name": "BackpackBattles.x86_64", "type": "Game" }
@@ -188,10 +186,3 @@
 
 # BUTCHER https://store.steampowered.com/app/474210/BUTCHER/
 { "name": "Butcher", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/linux-native/linux-native_c.rules
+++ b/00-default/Games/linux-native/linux-native_c.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### C ###
-
 
 # Capsized https://store.steampowered.com/app/95300/Capsized/
 { "name": "Capsized", "type": "Game" }
@@ -184,10 +182,3 @@
 
 # Cube Racer https://store.steampowered.com/app/705210/Cube_Racer/
 { "name": "CubeRacer.x86", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/linux-native/linux-native_d.rules
+++ b/00-default/Games/linux-native/linux-native_d.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### D ###
-
 
 # Danganronpa 2: Goodbye Despair https://store.steampowered.com/app/413420/Danganronpa_2_Goodbye_Despair/
 { "name": "Danganronpa2", "type": "Game" }
@@ -248,10 +246,3 @@
 
 # Dystopia https://store.steampowered.com/app/17580/Dystopia/
 { "name": "dystopia", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/linux-native/linux-native_e.rules
+++ b/00-default/Games/linux-native/linux-native_e.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### E ###
-
 
 # Earth 2160 https://store.steampowered.com/app/1900/Earth_2160/
 { "name": "RunEditor", "type": "Game" }
@@ -93,10 +91,3 @@
 # Expeditions: Conquistador https://store.steampowered.com/app/237430/Expeditions_Conquistador/
 { "name": "ExpeditionsConquistador.x86", "type": "Game" }
 { "name": "ExpeditionsConquistador.x86_64", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/linux-native/linux-native_f.rules
+++ b/00-default/Games/linux-native/linux-native_f.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### F ###
-
 
 # F1 2015 https://store.steampowered.com/app/286570/F1_2015/
 { "name": "F12015", "type": "Game" }
@@ -100,10 +98,3 @@
 
 # Fury Unleashed https://store.steampowered.com/app/465200/Fury_Unleashed/
 { "name": "FuryUnleashed.x86_64", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/linux-native/linux-native_g.rules
+++ b/00-default/Games/linux-native/linux-native_g.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### G ###
-
 
 # Gamblers Table https://store.steampowered.com/app/3618390/Gamblers_Table/
 { "name": "gamblers-table.x86_64", "type": "Game" }
@@ -34,9 +32,6 @@
 { "name": "GeminiRue.bin.x86", "type": "Game" }
 { "name": "GeminiRue.bin.x86_64", "type": "Game" }
 { "name": "winsetup", "type": "Game" }
-
-# Get name of game from steam.
-
 
 # Getting Over It with Bennett Foddy https://store.steampowered.com/app/240720/Getting_Over_It_with_Bennett_Foddy/
 { "name": "GettingOverIt.x86_64", "type": "Game" }
@@ -119,7 +114,3 @@
 # Guts and Glory https://store.steampowered.com/app/537340/Guts_and_Glory/
 { "name": "Guts and Glory.x86", "type": "Game" }
 { "name": "Guts and Glory.x86_64", "type": "Game" }
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/linux-native/linux-native_h.rules
+++ b/00-default/Games/linux-native/linux-native_h.rules
@@ -1,14 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
+# If not from any store add name you think it needs.
 
 ### H ###
-
 
 # Hacker Evolution https://store.steampowered.com/app/70100/Hacker_Evolution/
 { "name": "HackerEvolution", "type": "Game" }
@@ -173,7 +168,3 @@
 
 # Hytale https://hytale.com/
 { "name": "HytaleClient", "type": "Game" }
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/linux-native/linux-native_i.rules
+++ b/00-default/Games/linux-native/linux-native_i.rules
@@ -1,14 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
+# If not from any store add name you think it needs.
 
 ### I ###
-
 
 # ibb & obb https://store.steampowered.com/app/95400/ibb__obb/
 { "name": "ibbobb.elf", "type": "Game" }
@@ -28,9 +23,6 @@
 
 # Idol Manager https://store.steampowered.com/app/821880/Idol_Manager/
 { "name": "IdolManager.x86_64", "type": "Game" }
-
-# If not from any store add name you think it needs.
-
 
 # I Have No Mouth, and I Must Scream https://store.steampowered.com/app/245390/I_Have_No_Mouth_and_I_Must_Scream/
 { "name": "IHNMAIMS.x86_64", "type": "Game" }
@@ -114,4 +106,3 @@
 
 # Ittle Dew https://store.steampowered.com/app/241320/Ittle_Dew/
 { "name": "IttleDew.x86", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_j.rules
+++ b/00-default/Games/linux-native/linux-native_j.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### J ###
-
 
 # Jabroni Brawl: Episode 3 https://store.steampowered.com/app/869480/Jabroni_Brawl_Episode_3/
 { "name": "jbep3", "type": "Game" }
@@ -38,4 +30,3 @@
 
 # Just Shapes & Beats https://store.steampowered.com/app/531510/Just_Shapes__Beats/
 { "name": "JSB.x86_64", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_k.rules
+++ b/00-default/Games/linux-native/linux-native_k.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### K ###
-
 
 # Kabuto Park https://store.steampowered.com/app/3376990/Kabuto_Park/
 { "name": "KabutoPark.x86_64", "type": "Game" }
@@ -82,4 +74,3 @@
 
 # Kona https://store.steampowered.com/app/365160/Kona/
 { "name": "Kona.x86_64", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_l.rules
+++ b/00-default/Games/linux-native/linux-native_l.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### L ###
-
 
 # LA Cops https://store.steampowered.com/app/278810/LA_Cops/
 { "name": "lacops.x86", "type": "Game" }
@@ -103,4 +95,3 @@
 
 # LYNE https://store.steampowered.com/app/266010/LYNE/
 { "name": "LYNE.x64", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_m.rules
+++ b/00-default/Games/linux-native/linux-native_m.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### M ###
-
 
 # Mad Max https://store.steampowered.com/app/234140/Mad_Max/
 { "name": "MadMax", "type": "Game" }
@@ -147,4 +139,3 @@
 
 # MXGP3 - The Official Motocross Videogame https://store.steampowered.com/app/561600/MXGP3__The_Official_Motocross_Videogame/
 { "name": "mxgp3.x86_64", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_n.rules
+++ b/00-default/Games/linux-native/linux-native_n.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### N ###
-
 
 # Narcissu 1st & 2nd https://store.steampowered.com/app/264380/Narcissu_1st__2nd/
 { "name": "narcissu", "type": "Game" }
@@ -66,4 +58,3 @@
 
 # Nunholy https://store.steampowered.com/app/2854740/Nunholy/
 { "name": "Nunholy.x86_64", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_numerical.rules
+++ b/00-default/Games/linux-native/linux-native_numerical.rules
@@ -38,4 +38,3 @@
 # 9 Clues: The Secret of Serpent Creek https://store.steampowered.com/app/284870/9_Clues_The_Secret_of_Serpent_Creek/
 { "name": "NineClues_amd64", "type": "Game" }
 { "name": "NineClues_i386", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_o.rules
+++ b/00-default/Games/linux-native/linux-native_o.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### O ###
-
 
 # Octodad: Dadliest Catch https://store.steampowered.com/app/224480/Octodad_Dadliest_Catch/
 { "name": "OctodadDadliestCatch", "type": "Game" }
@@ -79,4 +71,3 @@
 
 # Oxygen Not Included https://store.steampowered.com/app/457140/Oxygen_Not_Included/
 { "name": "OxygenNotIncluded", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_p.rules
+++ b/00-default/Games/linux-native/linux-native_p.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### P ###
-
 
 # Packing Life https://store.steampowered.com/app/3482510/Packing_Life/
 { "name": "Packing Life.x86_64", "type": "Game" }
@@ -167,4 +159,3 @@
 
 # Punch Club https://store.steampowered.com/app/394310/Punch_Club/
 { "name": "Punch Club.x86", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_q.rules
+++ b/00-default/Games/linux-native/linux-native_q.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### Q ###
-
 
 # Quake II RTX https://store.steampowered.com/app/1089130/Quake_II_RTX/
 { "name": "q2rtxded", "type": "Game" }
@@ -35,4 +27,3 @@
 # Quiplash 2 InterLASHional https://store.steampowered.com/app/1111940/Quiplash_2_InterLASHional/
 { "name": "Quiplash2_Vulkan", "type": "Game" }
 { "name": "Quiplash2_OpenGL", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_r.rules
+++ b/00-default/Games/linux-native/linux-native_r.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### R ###
-
 
 # Race The Sun https://store.steampowered.com/app/253030/Race_The_Sun/
 { "name": "RaceTheSun.x86", "type": "Game" }
@@ -139,4 +131,3 @@
 
 # Rust https://store.steampowered.com/app/252490/Rust/
 { "name": "rust", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_s.rules
+++ b/00-default/Games/linux-native/linux-native_s.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### S ###
-
 
 # Saints Row 2 https://store.steampowered.com/app/9480/Saints_Row_2/
 { "name": "saintsrow2", "type": "Game" }
@@ -413,4 +405,3 @@
 # Symphony https://store.steampowered.com/app/207750/Symphony/
 { "name": "Symphony.bin.x86", "type": "Game" }
 { "name": "Symphony.bin.x86_64", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_t.rules
+++ b/00-default/Games/linux-native/linux-native_t.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### T ###
-
 
 # Tabletop Simulator https://store.steampowered.com/app/286160/Tabletop_Simulator/
 { "name": "Tabletop Simulator.x86_64", "type": "Game" }
@@ -238,4 +230,3 @@
 { "name": "tyr-glqwcl", "type": "Game" }
 { "name": "tyr-quake", "type": "Game" }
 { "name": "tyr-qwcl", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_the.rules
+++ b/00-default/Games/linux-native/linux-native_the.rules
@@ -1,17 +1,10 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
-
+# There are a lot of titles with "The" prefix. I want to separate these titles from the game titles actually start with "T".
 
 ### The ###
-
 
 # The 39 Steps https://store.steampowered.com/app/234940/The_39_Steps/
 { "name": "39stepslinux.x86", "type": "Game" }
@@ -159,9 +152,6 @@
 
 # The Plan https://store.steampowered.com/app/250600/The_Plan/
 { "name": "The Plan.x86", "type": "Game" }
-
-# There are a lot of titles with "The" prefix. I want to seperate these titles from the game titles actually start with "T"
-
 
 # The Roottrees are Dead https://store.steampowered.com/app/2754380/The_Roottrees_are_Dead/
 { "name": "roottrees", "type": "Game" }

--- a/00-default/Games/linux-native/linux-native_u.rules
+++ b/00-default/Games/linux-native/linux-native_u.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### U ###
-
 
 # Ultimate Chicken Horse https://store.steampowered.com/app/386940/Ultimate_Chicken_Horse/
 { "name": "UltimateChickenHorse.x86_64", "type": "Game" }
@@ -70,4 +62,3 @@
 # Urban Terror https://www.urbanterror.info/
 { "name": "Quake3-UrT.x86_64", "type": "Game" }
 { "name": "Quake3-UrT.i386", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_v.rules
+++ b/00-default/Games/linux-native/linux-native_v.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### V ###
-
 
 # Vagrus - The Riven Realms https://store.steampowered.com/app/909660/Vagrus__The_Riven_Realms/
 { "name": "Vagrus.x86_64", "type": "Game" }
@@ -61,4 +53,3 @@
 
 # VVVVVV https://store.steampowered.com/app/70300/VVVVVV/
 { "name": "VVVVVV", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_w.rules
+++ b/00-default/Games/linux-native/linux-native_w.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### W ###
-
 
 # Waking Mars https://store.steampowered.com/app/227200/Waking_Mars/
 { "name": "wakingmars", "type": "Game" }
@@ -104,4 +96,3 @@
 
 # WRATH: Aeon of Ruin https://store.steampowered.com/app/1000410/WRATH_Aeon_of_Ruin/
 { "name": "wrath-steam", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_x.rules
+++ b/00-default/Games/linux-native/linux-native_x.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### X ###
-
 
 # X3: Terran Conflict https://store.steampowered.com/app/2820/X3_Terran_Conflict/
 { "name": "X3TC_main", "type": "Game" }
@@ -37,4 +29,3 @@
 
 # X Rebirth https://store.steampowered.com/app/2870/X_Rebirth/
 { "name": "XRebirth", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_y.rules
+++ b/00-default/Games/linux-native/linux-native_y.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### Y ###
-
 
 # yamagi-quake2 https://www.yamagi.org/quake2/
 { "name": "quake2", "type": "Game" }
@@ -38,4 +30,3 @@
 
 # Yuppie Psycho: Executive Edition https://store.steampowered.com/app/597760/Yuppie_Psycho_Executive_Edition/
 { "name": "yuppiepsycho", "type": "Game" }
-

--- a/00-default/Games/linux-native/linux-native_z.rules
+++ b/00-default/Games/linux-native/linux-native_z.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### Z ###
-
 
 # zdoom https://zdoom.org/
 { "name": "gzdoom", "type": "Game" }
@@ -26,4 +18,3 @@
 
 # Zombie Panic! Source https://store.steampowered.com/app/17500/Zombie_Panic_Source/
 { "name": "zps_linux", "type": "Game" }
-

--- a/00-default/Games/wine_proton/common.rules
+++ b/00-default/Games/wine_proton/common.rules
@@ -1,6 +1,3 @@
-# Add name of game next to the url.
-# Get name of game from steam.
-# If not from any store add name you think it needs.
 # Ordered based on executable name
 
 # Age of Darkness: Final Stand https://store.steampowered.com/app/1426450/Age_of_Darkness_Final_Stand/

--- a/00-default/Games/wine_proton/wine_proton_a.rules
+++ b/00-default/Games/wine_proton/wine_proton_a.rules
@@ -1,5 +1,9 @@
-### A ###
+# Add games in alphabetical order.
+# Add name of game next to the url.
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
+### A ###
 
 # AaaaaAAaaaAAAaaAAAAaAAAAA!!! for the Awesome https://store.steampowered.com/app/15560/AaaaaAAaaaAAAaaAAAAaAAAAA_for_the_Awesome/
 { "name": "Awesome.exe", "type": "Game" }
@@ -61,12 +65,6 @@
 
 # A Date with Death https://store.steampowered.com/app/2415010/A_Date_with_Death/
 { "name": "ADatewithDeath.exe", "type": "Game" }
-
-# Add games in alphabetical order.
-
-
-# Add name of game next to the url.
-
 
 # Ad Infinitum https://store.steampowered.com/app/1234430/Ad_Infinitum/
 { "name": "AdInfinitum.exe", "type": "Game" }
@@ -883,10 +881,3 @@
 # Azur Lane Crosswave https://store.steampowered.com/app/1150080/Azur_Lane_Crosswave/
 { "name": "Azurlane.exe", "type": "Game" }
 { "name": "Azurlane-Win64-Shipping.exe", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/wine_proton/wine_proton_b.rules
+++ b/00-default/Games/wine_proton/wine_proton_b.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### B ###
-
 
 # Baba Is You https://store.steampowered.com/app/736260/Baba_Is_You/
 { "name": "Baba Is You.exe", "type": "Game" }
@@ -804,10 +802,3 @@
 
 # Bye Sweet Carole https://store.steampowered.com/app/2428980/Bye_Sweet_Carole/
 { "name": "Bye Sweet Carole.exe", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/wine_proton/wine_proton_c.rules
+++ b/00-default/Games/wine_proton/wine_proton_c.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### C ###
-
 
 # CABAL Online https://store.steampowered.com/app/253490/CABAL_Online/
 { "name": "cabal.exe", "type": "Game" }
@@ -925,10 +923,3 @@
 # Cyberpunk 2077 https://store.steampowered.com/app/1091500/Cyberpunk_2077/
 { "name": "Cyberpunk2077.exe", "type": "Game" }
 { "name": "Redprelauncher", "type": "BG_CPUIO" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/wine_proton/wine_proton_d.rules
+++ b/00-default/Games/wine_proton/wine_proton_d.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### D ###
-
 
 # Daikatana https://store.steampowered.com/app/242980/Daikatana/
 { "name": "daikatana.exe", "type": "Game" }
@@ -1022,10 +1020,3 @@
 
 # Dystopika https://store.steampowered.com/app/2379910/Dystopika/
 { "name": "Dystopika.exe", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/wine_proton/wine_proton_e.rules
+++ b/00-default/Games/wine_proton/wine_proton_e.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### E ###
-
 
 # Earth 2160 https://store.steampowered.com/app/1900/Earth_2160/
 { "name": "Earth2160Editor_START.exe", "type": "Game" }
@@ -382,10 +380,3 @@
 
 # EZ2ON REBOOT : R https://store.steampowered.com/app/1477590/EZ2ON_REBOOT__R/
 { "name": "EZ2ON.exe", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/wine_proton/wine_proton_f.rules
+++ b/00-default/Games/wine_proton/wine_proton_f.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### F ###
-
 
 # F1 2012 https://store.steampowered.com/app/208500/F1_2012/
 { "name": "F1_2012.exe", "type": "Game" }
@@ -661,10 +659,3 @@
 
 # Fury Unleashed https://store.steampowered.com/app/465200/Fury_Unleashed/
 { "name": "FuryUnleashed.exe", "type": "Game" }
-
-# Get name of game from steam.
-
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/wine_proton/wine_proton_g.rules
+++ b/00-default/Games/wine_proton/wine_proton_g.rules
@@ -1,11 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
+# Get name of game from steam.
+# If not from any store add name you think it needs.
 
 ### G ###
-
 
 # Gabriel Knight: Sins of the Fathers 20th Anniversary Edition https://store.steampowered.com/app/262000/Gabriel_Knight_Sins_of_the_Fathers_20th_Anniversary_Edition/
 { "name": "GK1.exe", "type": "Game" }
@@ -135,9 +133,6 @@
 
 # GET EVEN https://store.steampowered.com/app/299950/GET_EVEN/
 { "name": "GetEven.exe", "type": "Game" }
-
-# Get name of game from steam.
-
 
 # Get Off My Lawn! https://store.steampowered.com/app/260410/Get_Off_My_Lawn/
 { "name": "goml.exe", "type": "Game" }
@@ -575,7 +570,3 @@
 
 # Gym Simulator 24 https://store.steampowered.com/app/2559270/Gym_Simulator_24/
 { "name": "GymSimulator24.exe", "type": "Game" }
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/wine_proton/wine_proton_h.rules
+++ b/00-default/Games/wine_proton/wine_proton_h.rules
@@ -1,14 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
+# If not from any store add name you think it needs.
 
 ### H ###
-
 
 # Hachishaku https://store.steampowered.com/app/3572580/Hachishaku/
 { "name": "Hachishaku.exe", "type": "Game" }
@@ -570,7 +565,3 @@
 
 # Hypnospace Outlaw https://store.steampowered.com/app/844590/Hypnospace_Outlaw/
 { "name": "HypnOS.exe", "type": "Game" }
-
-# If not from any store add name you think it needs.
-
-

--- a/00-default/Games/wine_proton/wine_proton_i.rules
+++ b/00-default/Games/wine_proton/wine_proton_i.rules
@@ -1,14 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
+# If not from any store add name you think it needs.
 
 ### I ###
-
 
 # I Am Alive https://store.steampowered.com/app/214250/I_Am_Alive/
 { "name": "iamalive_game.exe", "type": "Game" }
@@ -67,9 +62,6 @@
 
 # If Found... https://store.steampowered.com/app/1041920/If_Found/
 { "name": "iffound.exe", "type": "Game" }
-
-# If not from any store add name you think it needs.
-
 
 # I Have No Mouth, and I Must Scream https://store.steampowered.com/app/245390/I_Have_No_Mouth_and_I_Must_Scream/
 { "name": "IHNMAIMS.exe", "type": "Game" }
@@ -292,4 +284,3 @@
 
 # I, Zombie https://store.steampowered.com/app/307230/I_Zombie/
 { "name": "I, Zombie.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_j.rules
+++ b/00-default/Games/wine_proton/wine_proton_j.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### J ###
-
 
 # Jabroni Brawl: Episode 3 https://store.steampowered.com/app/869480/Jabroni_Brawl_Episode_3/
 { "name": "dmxconvert.exe", "type": "Game" }
@@ -136,4 +128,3 @@
 
 # Just Shapes & Beats https://store.steampowered.com/app/531510/Just_Shapes__Beats/
 { "name": "JSB.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_k.rules
+++ b/00-default/Games/wine_proton/wine_proton_k.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### K ###
-
 
 # Kabuto Park https://store.steampowered.com/app/3376990/Kabuto_Park/
 { "name": "KabutoPark.exe", "type": "Game" }
@@ -277,4 +269,3 @@
 
 # Kynseed https://store.steampowered.com/app/758870/Kynseed/
 { "name": "Kynseed.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_l.rules
+++ b/00-default/Games/wine_proton/wine_proton_l.rules
@@ -365,9 +365,6 @@
 # Loop Hero https://store.steampowered.com/app/1282730/Loop_Hero/
 { "name": "Loop Hero.exe", "type": "Game" }
 
-# Lorelei and the Laser Eyes https://store.steampowered.com/app/2008920/Lorelei_and_the_Laser_Eyes/
-{ "name": "Lorelei and the Laser Eyes.exe", "type": "Game" }
-
 # Lord of the Rings: War in the North https://store.steampowered.com/app/32800/Lord_of_the_Rings_War_in_the_North/
 { "name": "witn.exe", "type": "Game" }
 
@@ -380,6 +377,9 @@
 
 # Lords Of The Fallen 2014 https://store.steampowered.com/app/265300/Lords_Of_The_Fallen_2014/
 { "name": "LordsOfTheFallen.exe", "type": "Game" }
+
+# Lorelei and the Laser Eyes https://store.steampowered.com/app/2008920/Lorelei_and_the_Laser_Eyes/
+{ "name": "Lorelei and the Laser Eyes.exe", "type": "Game" }
 
 # LORT https://store.steampowered.com/app/2956680/LORT/
 { "name": "LortGame-Win64-Shipping.exe", "type": "Game" }
@@ -472,4 +472,3 @@
 
 # LYNE https://store.steampowered.com/app/266010/LYNE/
 { "name": "LYNE.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_m.rules
+++ b/00-default/Games/wine_proton/wine_proton_m.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### M ###
-
 
 # Machinarium https://store.steampowered.com/app/40700/Machinarium/
 { "name": "Machinarium.exe", "type": "Game" }
@@ -927,4 +919,3 @@
 { "name": "Tracy.exe", "type": "Game" }
 { "name": "NS2.exe", "type": "Game" }
 { "name": "ns2.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_n.rules
+++ b/00-default/Games/wine_proton/wine_proton_n.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### N ###
-
 
 # nail'd https://store.steampowered.com/app/40380/naild/
 { "name": "Naild_x86.exe", "type": "Game" }
@@ -426,4 +418,3 @@
 
 # Nunholy https://store.steampowered.com/app/2854740/Nunholy/
 { "name": "Nunholy.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_numerical.rules
+++ b/00-default/Games/wine_proton/wine_proton_numerical.rules
@@ -92,4 +92,3 @@
 
 # 9 Years of Shadows https://store.steampowered.com/app/1402120/9_Years_of_Shadows/
 { "name": "9 Years of Shadows.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_o.rules
+++ b/00-default/Games/wine_proton/wine_proton_o.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### O ###
-
 
 # Obenseuer https://store.steampowered.com/app/951240/Obenseuer/
 { "name": "Obenseuer.exe", "type": "Game" }
@@ -353,4 +345,3 @@
 
 # Oxygen Not Included https://store.steampowered.com/app/457140/Oxygen_Not_Included/
 { "name": "OxygenNotIncluded.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_p.rules
+++ b/00-default/Games/wine_proton/wine_proton_p.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### P ###
-
 
 # Pacific Drive https://store.steampowered.com/app/1458140/Pacific_Drive/
 { "name": "PenDriverPro.exe", "type": "Game" }
@@ -730,4 +722,3 @@
 
 # Puzzle Together https://store.steampowered.com/app/1478220/Puzzle_Together_Multiplayer_Jigsaw_Puzzles/
 { "name": "Puzzle Together.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_q.rules
+++ b/00-default/Games/wine_proton/wine_proton_q.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### Q ###
-
 
 # Quake https://store.steampowered.com/app/2310/Quake/
 { "name": "Quake_x64_steam.exe", "type": "Game" }
@@ -62,4 +54,3 @@
 
 # Quiplash 2 InterLASHional https://store.steampowered.com/app/1111940/Quiplash_2_InterLASHional/
 { "name": "Quiplash 2 InterLASHional.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_r.rules
+++ b/00-default/Games/wine_proton/wine_proton_r.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### R ###
-
 
 # Rabbit and Steel https://store.steampowered.com/app/2132850/Rabbit_and_Steel/
 { "name": "RabbitSteel.exe", "type": "Game" }
@@ -775,4 +767,3 @@
 
 # Ryse: Son of Rome https://store.steampowered.com/app/302510/Ryse_Son_of_Rome/
 { "name": "Ryse.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_s.rules
+++ b/00-default/Games/wine_proton/wine_proton_s.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### S ###
-
 
 # Sable https://store.steampowered.com/app/757310/Sable/
 { "name": "Seble.exe", "type": "Game" }
@@ -1782,4 +1774,3 @@
 
 # System Shock 2 https://store.steampowered.com/app/238210/System_Shock_2_1999/
 { "name": "SS2.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_t.rules
+++ b/00-default/Games/wine_proton/wine_proton_t.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### T ###
-
 
 # Tabletop Simulator https://store.steampowered.com/app/286160/Tabletop_Simulator/
 { "name": "Tabletop Simulator.exe", "type": "Game" }
@@ -901,4 +893,3 @@
 
 # Tyranny https://store.steampowered.com/app/362960/Tyranny/
 { "name": "Tyranny.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_the.rules
+++ b/00-default/Games/wine_proton/wine_proton_the.rules
@@ -1,17 +1,10 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
-
+# There are a lot of titles with "The" prefix. I want to separate these titles from the game titles actually start with "T".
 
 ### The ###
-
 
 # The 39 Steps https://store.steampowered.com/app/234940/The_39_Steps/
 { "name": "39steps.exe", "type": "Game" }
@@ -552,9 +545,6 @@
 # The Ranch of Rivershine https://store.steampowered.com/app/1559600/The_Ranch_of_Rivershine/
 { "name": "TheRanchOfRivershine.exe", "type": "Game" }
 { "name": "TheRanchOfRivershine-Win64-Shipping.exe", "type": "Game" }
-
-# There are a lot of titles with "The" prefix. I want to separate these titles from the game titles actually start with "T"
-
 
 # The Room https://store.steampowered.com/app/288160/The_Room/
 { "name": "TheRoom.exe", "type": "Game" }

--- a/00-default/Games/wine_proton/wine_proton_u.rules
+++ b/00-default/Games/wine_proton/wine_proton_u.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### U ###
-
 
 # UBERMOSH https://store.steampowered.com/app/357070/UBERMOSH/
 { "name": "UBERMOSH.exe", "type": "Game" }
@@ -184,4 +176,3 @@
 # Uriel's Chasm https://store.steampowered.com/app/292630/Uriels_Chasm/
 { "name": "dxwebsetup.exe", "type": "Game" }
 { "name": "urielschasm.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_v.rules
+++ b/00-default/Games/wine_proton/wine_proton_v.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### V ###
-
 
 # VA-11 Hall-A: Cyberpunk Bartender Action https://store.steampowered.com/app/447530/VA11_HallA_Cyberpunk_Bartender_Action/
 { "name": "VA-11 Hall A.exe", "type": "Game" }
@@ -199,4 +191,3 @@
 
 # VVVVVV https://store.steampowered.com/app/70300/VVVVVV/
 { "name": "VVVVVV.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_w.rules
+++ b/00-default/Games/wine_proton/wine_proton_w.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### W ###
-
 
 # Waifusitter 🔞 - Furry Collection https://store.steampowered.com/app/3427660/Waifusitter___Furry_Collection/
 { "name": "Waifusitter.exe", "type": "Game" }
@@ -588,4 +580,3 @@
 
 # WWII Online https://store.steampowered.com/app/251950/WWII_Online/
 { "name": "WW2.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_x.rules
+++ b/00-default/Games/wine_proton/wine_proton_x.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### X ###
-
 
 # X3: Terran Conflict https://store.steampowered.com/app/2820/X3_Terran_Conflict/
 { "name": "X3TC.exe", "type": "Game" }
@@ -53,4 +45,3 @@
 # Xuan-Yuan Sword: The Scar of Sky https://store.steampowered.com/app/1638220/XuanYuan_Sword_The_Scar_of_Sky/
 { "name": "swd3e.exe", "type": "Game" }
 { "name": "Ghost.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_y.rules
+++ b/00-default/Games/wine_proton/wine_proton_y.rules
@@ -1,17 +1,9 @@
 # Add games in alphabetical order.
-
-
 # Add name of game next to the url.
-
-
 # Get name of game from steam.
-
-
 # If not from any store add name you think it needs.
 
-
 ### Y ###
-
 
 # YAIBA: NINJA GAIDEN Z https://store.steampowered.com/app/252230/YAIBA_NINJA_GAIDEN_Z/
 { "name": "NRZGame.exe", "type": "Game" }
@@ -173,4 +165,3 @@
 
 # Yuppie Psycho: Executive Edition https://store.steampowered.com/app/597760/Yuppie_Psycho_Executive_Edition/
 { "name": "yuppiepsycho.exe", "type": "Game" }
-

--- a/00-default/Games/wine_proton/wine_proton_z.rules
+++ b/00-default/Games/wine_proton/wine_proton_z.rules
@@ -104,4 +104,3 @@
 
 # Zup! S https://store.steampowered.com/app/617670/Zup_S/
 { "name": "Zup! S.exe", "type": "Game" }
-

--- a/sort-games.sh
+++ b/sort-games.sh
@@ -1,28 +1,33 @@
 #!/usr/bin/env bash
 
-# make sure that file that you are sorting only has games defined like this:
+# this script can sort rules in wine_proton and linux-native folders
+# don't use this script to sort common.rules and non-latin rules
+# use it to sort files "from a to z", "the" and numerical
 
-# # The Age of Decadence https://store.steampowered.com/app/230070/The_Age_of_Decadence/
-# { "name": "AoD.exe", "type": "Game" }
-# { "name": "AoD64.exe", "type": "Game" }
-
-# temporarily remove extra comments from the file before sorting and add them back afterward
-# don't use this script to sort common.rules and non-latin
 # Usage: ./sort_elements.sh wine_proton_a.rules
+#
+# Usage to sort multiple files with single command (a to z). run this script in the root of the repo
+# 
+# for letter in {a..z}; do
+#     ./sort-games.sh "00-default/Games/wine_proton/wine_proton_${letter}.rules"
+# done
+#
+# for letter in {a..z}; do
+#     ./sort-games.sh "00-default/Games/linux-native/linux-native_${letter}.rules"
+# done
 
 
 parse_and_sort() {
     local file="$1"
     local -A ids names jsons
-
     local current_id="" current_name="" current_jsons=""
 
     save_element() {
-		if [[ -z "$current_id" ]]; then
-    		[[ -z "$current_name" ]] && return
-    		echo "ERROR: empty id for entry: $current_name" >&2
-    		exit 1
-		fi
+        if [[ -z "$current_id" ]]; then
+            [[ -z "$current_name" ]] && return
+            echo "ERROR: empty id for entry: $current_name" >&2
+            exit 1
+        fi
         if [[ -n "${ids[$current_id]+_}" ]]; then
             echo "ERROR: duplicate id '$current_id', found in: $current_name" >&2
             exit 1
@@ -37,7 +42,35 @@ parse_and_sort() {
         echo "$title" | sed 's/http.*//' | sed 's/[^a-zA-Z0-9 ]//g' | tr -d ' ' | tr '[:upper:]' '[:lower:]'
     }
 
-    while IFS= read -r line || [[ -n "$line" ]]; do
+    is_header_line() {
+        local l="$1"
+        [[ -z "$l" ]] && return 0
+        [[ "$l" == "# Add games in alphabetical order." ]] && return 0
+        [[ "$l" == "# Add name of game next to the url." ]] && return 0
+        [[ "$l" == "# Get name of game from steam." ]] && return 0
+        [[ "$l" == "# If not from any store add name you think it needs." ]] && return 0
+        [[ "$l" == "# There are a lot of titles with \"The\" prefix. I want to separate these titles from the game titles actually start with \"T\"." ]] && return 0
+        [[ "$l" == "### "* ]] && return 0
+        return 1
+    }
+
+    local header=""
+    local header_line_count=0
+    local all_lines=()
+    mapfile -t all_lines < "$file"
+
+    for line in "${all_lines[@]}"; do
+        if is_header_line "$line"; then
+            header+="$line"$'\n'
+            (( header_line_count++ ))
+        else
+            break
+        fi
+    done
+
+    local body_lines=("${all_lines[@]:$header_line_count}")
+
+    for line in "${body_lines[@]}"; do
         if [[ "$line" == \#* ]]; then
             save_element
             current_name="$line"
@@ -48,20 +81,25 @@ parse_and_sort() {
             [[ -n "$current_jsons" ]] && current_jsons+=$'\n'
             current_jsons+="$line"
         fi
-    done < "$file"
+    done
 
     save_element
 
     local sorted_ids
     mapfile -t sorted_ids < <(printf '%s\n' "${!ids[@]}" | sort)
 
-    local output=""
+    local output="${header%$'\n'}"$'\n'
+    local last_id="${sorted_ids[-1]}"
     for id in "${sorted_ids[@]}"; do
         output+="${names[$id]}"$'\n'
-        output+="${jsons[$id]}"$'\n'$'\n'
+        if [[ "$id" == "$last_id" ]]; then
+            output+="${jsons[$id]}"$'\n'
+        else
+            output+="${jsons[$id]}"$'\n'$'\n'
+        fi
     done
 
-    printf '%s' "$output" > "$file"
+    printf '%s' "${output%$'\n'}" > "$file"
 }
 
 parse_and_sort "${1}"


### PR DESCRIPTION
@pollux78 i also updated/improved sort script
now it can preserve comments at the start of file.
this is comments from script file. it's more easy to read here :P
try it out and tell me if something is confusing.

this script can sort rules in wine_proton and linux-native folders
don't use this script to sort common.rules and non-latin rules
use it to sort files "from a to z", "the" and numerical

Usage:
```
 ./sort_elements.sh wine_proton_a.rules
```

Usage to sort multiple files with single command (a to z). run this script in the root of the repo
 
```
for letter in {a..z}; do
    ./sort-games.sh "00-default/Games/wine_proton/wine_proton_${letter}.rules"
done
```

```
for letter in {a..z}; do
     ./sort-games.sh "00-default/Games/linux-native/linux-native_${letter}.rules"
done
```