### PR TITLE
Improvements & fixes

### DIFF
--- a/00-default/Games/wine_proton/wine_proton_g.rules
+++ b/00-default/Games/wine_proton/wine_proton_g.rules
@@ -85,7 +85,7 @@
 
 # Gears 5 https://store.steampowered.com/app/1097840/Gears_5/
 { "name": "Gears5.exe", "type": "Game" }
-{ "name": "Gears5_EAC.exe", "type": "Game" }
+{ "name": "Gears5_EAC.exe", "type": "BG_CPUIO" }
 
 # Gears of War: Reloaded https://store.steampowered.com/app/2523720/Gears_of_War_Reloaded/
 { "name": "GOWDE-Steam.exe", "type": "Game" }

--- a/00-default/Games/wine_proton/wine_proton_i.rules
+++ b/00-default/Games/wine_proton/wine_proton_i.rules
@@ -190,7 +190,7 @@
 # Insurgency: Sandstorm https://store.steampowered.com/app/581320/Insurgency_Sandstorm/
 { "name": "Insurgency.exe", "type": "Game" }
 { "name": "InsurgencyClient-Win64-Shipping.exe", "type": "Game" }
-{ "name": "InsurgencyEAC.exe", "type": "Game" }
+{ "name": "InsurgencyEAC.exe", "type": "BG_CPUIO" }
 
 # Interstellar Marines https://store.steampowered.com/app/236370/Interstellar_Marines/
 { "name": "InterstellarMarines.exe", "type": "Game" }

--- a/00-default/Games/wine_proton/wine_proton_p.rules
+++ b/00-default/Games/wine_proton/wine_proton_p.rules
@@ -53,8 +53,9 @@
 { "name": "PaintTheTownRedVR.exe", "type": "Game" }
 
 # Paladins https://store.steampowered.com/app/444090/Paladins/
-{ "name": "PaladinsEAC.exe", "type": "Game" }
+{ "name": "PaladinsEAC.exe", "type": "BG_CPUIO" }
 { "name": "Paladins.exe", "type": "Game" }
+{ "name": "ShippingPC-ChaosGame.exe", "type": "Game" }
 
 # Paleo Pines https://store.steampowered.com/app/1202200/Paleo_Pines/
 { "name": "Paleo Pines.exe", "type": "Game" }

--- a/00-default/Games/wine_proton/wine_proton_s.rules
+++ b/00-default/Games/wine_proton/wine_proton_s.rules
@@ -731,8 +731,9 @@
 { "name": "SmallWorld.exe", "type": "Game" }
 
 # SMITE https://store.steampowered.com/app/386360/SMITE/
-{ "name": "SmiteEAC.exe", "type": "Game" }
+{ "name": "SmiteEAC.exe", "type": "BG_CPUIO" }
 { "name": "Smite.exe", "type": "Game" }
+{ "name": "ShippingPC-BattleGame.exe", "type": "Game" }
 
 # SMITE 2 https://store.steampowered.com/app/2437170/SMITE_2/
 { "name": "Hemingway.exe", "type": "Game" }

--- a/00-default/Games/wine_proton/wine_proton_t.rules
+++ b/00-default/Games/wine_proton/wine_proton_t.rules
@@ -500,7 +500,7 @@
 # Tom Clancy’s The Division 2 https://store.steampowered.com/app/2221490/Tom_Clancys_The_Division_2/
 { "name": "TheDivision2.exe", "type": "Game" }
 { "name": "thedivision2launcher.exe", "type": "Game" }
-{ "name": "EACLaunch.exe", "type": "Game" }
+{ "name": "EACLaunch.exe", "type": "BG_CPUIO" }
 
 # Tony Hawk's Pro Skater 1 + 2 https://store.steampowered.com/app/2395210/Tony_Hawks_Pro_Skater_1__2/
 { "name": "THPS12.exe", "type": "Game" }


### PR DESCRIPTION
This PR:
changes few process types from Game to BG_CPUIO
adds missing processes to Paladins and SMITE

i found this and verified stuff in our repo.
[Mangohud BlackList](https://github.com/flightlessmango/MangoHud/blob/master/src/blacklist.cpp)

i wonder if we should add "Missing" launchers here...