### PR TITLE
Fix: dbus niceness incorrectly increased from the default

### DIFF
--- a/00-default/Services/dbus.rules
+++ b/00-default/Services/dbus.rules
@@ -1,5 +1,5 @@
 # D-Bus is a message bus system that provides an easy way for inter-process communication.
 # https://wiki.archlinux.org/title/D-Bus and https://dbus.freedesktop.org/doc/dbus-daemon.1.html
-{ "name": "dbus-daemon", "type": "Service" }
-{ "name": "dbus-broker", "type": "Service" }
-{ "name": "dbus-broker-launch", "type": "Service" }
+{ "name": "dbus-daemon", "type": "LowLatency_RT" }
+{ "name": "dbus-broker", "type": "LowLatency_RT" }
+{ "name": "dbus-broker-launch", "type": "LowLatency_RT" }


### PR DESCRIPTION
dbus is an IPC daemon. This means that it's relatively lightweight and should run frequently even under heavy load to maintain responsiveness.

I'm relatively sure this is the root cause of alt+tab not working properly under heavy load on COSMIC when using cachyos's ananicy-cpp rules