### PR TITLE
Adding a few VNs and two new emulators: 86Box and Mesen via wine, for those who use mouse with extra keys

### DIFF
--- a/00-default/Games/emulators.rules
+++ b/00-default/Games/emulators.rules
@@ -68,6 +68,9 @@
 # DOSBox, an x86 emulator with DOS https://www.dosbox.com/
 { "name": "dosbox", "type": "Game" }
 
+# 86Box, an x86 emulator with Win9X https://www.86box.net/
+{ "name": "86Box", "type": "Game" }
+
 ### Sega ###
 
 # BlastEm is an open source, higly accurate emulator for the Sega Genesis/Megadrive. https://www.retrodev.com/blastem/

--- a/00-default/Games/wine_proton/common.rules
+++ b/00-default/Games/wine_proton/common.rules
@@ -603,6 +603,11 @@
 # Lost Lands: Mahjong https://store.steampowered.com/app/435030/Lost_Lands_Mahjong/
 { "name": "Mahjong.exe", "type": "Game" }
 
+# Mainichi Kiss Shite Lolita https://www.mobygames.com/game/246927/lolita-kiss-me-everyday/
+{ "name": "lol7.exe", "type": "Game" }
+{ "name": "KissMeEveryday.exe", "type": "Game" }
+{ "name": "KissMeEveryday-HD.exe", "type": "Game" }
+
 # Majesty 2 https://store.steampowered.com/app/25980/Majesty_2/
 # Majesty 2 Collection https://store.steampowered.com/app/73020/Majesty_2_Collection/
 { "name": "Majesty2.exe", "type": "Game" }
@@ -650,6 +655,9 @@
 # Nightmare Reaper https://store.steampowered.com/app/1051690/Nightmare_Reaper/
 # Erzurum https://store.steampowered.com/app/1392060/Erzurum/
 { "name": "MyProject-Win64-Shipping.exe", "type": "Game" }
+
+# Naisho No Jikan https://www.myabandonware.com/game/naisho-no-jikan-109u
+{ "name": "naisho.exe", "type": "Game" }
 
 # Necromunda: Hired Gun https://store.steampowered.com/app/1222370/Necromunda_Hired_Gun/
 # Necromunda: Underhive Wars https://store.steampowered.com/app/566440/Necromunda_Underhive_Wars/

--- a/00-default/Games/wine_proton/common.rules
+++ b/00-default/Games/wine_proton/common.rules
@@ -525,6 +525,11 @@
 # Kingdom Come: Deliverance II https://store.steampowered.com/app/1771300/Kingdom_Come_Deliverance_II/
 { "name": "KingdomCome.exe", "type": "Game" }
 
+# Mainichi Kiss Shite Lolita https://www.mobygames.com/game/246927/lolita-kiss-me-everyday/
+{ "name": "lol7.exe", "type": "Game" }
+{ "name": "KissMeEveryday.exe", "type": "Game" }
+{ "name": "KissMeEveryday-HD.exe", "type": "Game" }
+
 # Wolfenstein 3D https://store.steampowered.com/app/2270/Wolfenstein_3D/
 # Another Brick in The Mall https://store.steampowered.com/app/521150/Another_Brick_in_The_Mall/
 { "name": "launch.exe", "type": "Game" }
@@ -603,11 +608,6 @@
 # Lost Lands: Mahjong https://store.steampowered.com/app/435030/Lost_Lands_Mahjong/
 { "name": "Mahjong.exe", "type": "Game" }
 
-# Mainichi Kiss Shite Lolita https://www.mobygames.com/game/246927/lolita-kiss-me-everyday/
-{ "name": "lol7.exe", "type": "Game" }
-{ "name": "KissMeEveryday.exe", "type": "Game" }
-{ "name": "KissMeEveryday-HD.exe", "type": "Game" }
-
 # Majesty 2 https://store.steampowered.com/app/25980/Majesty_2/
 # Majesty 2 Collection https://store.steampowered.com/app/73020/Majesty_2_Collection/
 { "name": "Majesty2.exe", "type": "Game" }
@@ -631,6 +631,9 @@
 # MechWarrior 5: Clans https://store.steampowered.com/app/2000890/MechWarrior_5_Clans/
 # MechWarrior 5: Mercenaries https://store.steampowered.com/app/784080/MechWarrior_5_Mercenaries/
 { "name": "MechWarrior-Win64-Shipping.exe", "type": "Game" }
+
+# Mesen N******* multi-emulator via wine for SDL2 mouse keys https://www.mesen.ca/
+{ "name": "Mesen.exe", "type": "Game" }
 
 # Metro: Last Light Redux https://store.steampowered.com/app/287390/Metro_Last_Light_Redux/
 # Metro 2033 Redux https://store.steampowered.com/app/286690/Metro_2033_Redux/

--- a/00-default/Games/wine_proton/common.rules
+++ b/00-default/Games/wine_proton/common.rules
@@ -525,11 +525,6 @@
 # Kingdom Come: Deliverance II https://store.steampowered.com/app/1771300/Kingdom_Come_Deliverance_II/
 { "name": "KingdomCome.exe", "type": "Game" }
 
-# Mainichi Kiss Shite Lolita https://www.mobygames.com/game/246927/lolita-kiss-me-everyday/
-{ "name": "lol7.exe", "type": "Game" }
-{ "name": "KissMeEveryday.exe", "type": "Game" }
-{ "name": "KissMeEveryday-HD.exe", "type": "Game" }
-
 # Wolfenstein 3D https://store.steampowered.com/app/2270/Wolfenstein_3D/
 # Another Brick in The Mall https://store.steampowered.com/app/521150/Another_Brick_in_The_Mall/
 { "name": "launch.exe", "type": "Game" }
@@ -632,9 +627,6 @@
 # MechWarrior 5: Mercenaries https://store.steampowered.com/app/784080/MechWarrior_5_Mercenaries/
 { "name": "MechWarrior-Win64-Shipping.exe", "type": "Game" }
 
-# Mesen N******* multi-emulator via wine for SDL2 mouse keys https://www.mesen.ca/
-{ "name": "Mesen.exe", "type": "Game" }
-
 # Metro: Last Light Redux https://store.steampowered.com/app/287390/Metro_Last_Light_Redux/
 # Metro 2033 Redux https://store.steampowered.com/app/286690/Metro_2033_Redux/
 { "name": "metro.exe", "type": "Game" }
@@ -658,9 +650,6 @@
 # Nightmare Reaper https://store.steampowered.com/app/1051690/Nightmare_Reaper/
 # Erzurum https://store.steampowered.com/app/1392060/Erzurum/
 { "name": "MyProject-Win64-Shipping.exe", "type": "Game" }
-
-# Naisho No Jikan https://www.myabandonware.com/game/naisho-no-jikan-109u
-{ "name": "naisho.exe", "type": "Game" }
 
 # Necromunda: Hired Gun https://store.steampowered.com/app/1222370/Necromunda_Hired_Gun/
 # Necromunda: Underhive Wars https://store.steampowered.com/app/566440/Necromunda_Underhive_Wars/
@@ -699,9 +688,6 @@
 # Choo-Choo Charles https://store.steampowered.com/app/1766740/ChooChoo_Charles/
 # Obscure https://store.steampowered.com/app/254460/Obscure/
 { "name": "Obscure.exe", "type": "Game" }
-
-# Onii Kiss https://nekonyansoft.com/blog/saving-the-sisters-announcing-onikiss-re-release
-{ "name": "OniiKiss.exe", "type": "Game" }
 
 # OPERATOR https://store.steampowered.com/app/1913370/OPERATOR/
 # The Operator https://store.steampowered.com/app/1771980/The_Operator/

--- a/00-default/Games/wine_proton/common.rules
+++ b/00-default/Games/wine_proton/common.rules
@@ -697,6 +697,9 @@
 # Obscure https://store.steampowered.com/app/254460/Obscure/
 { "name": "Obscure.exe", "type": "Game" }
 
+# Onii Kiss https://nekonyansoft.com/blog/saving-the-sisters-announcing-onikiss-re-release
+{ "name": "OniiKiss.exe", "type": "Game" }
+
 # OPERATOR https://store.steampowered.com/app/1913370/OPERATOR/
 # The Operator https://store.steampowered.com/app/1771980/The_Operator/
 { "name": "OPERATOR.exe", "type": "Game" }

--- a/00-default/Games/wine_proton/wine_proton_m.rules
+++ b/00-default/Games/wine_proton/wine_proton_m.rules
@@ -121,6 +121,11 @@
 # Mail Time https://store.steampowered.com/app/1607240/Mail_Time/
 { "name": "MailTime.exe", "type": "Game" }
 
+# Mainichi Kiss Shite Lolita https://www.mobygames.com/game/246927/lolita-kiss-me-everyday/
+{ "name": "lol7.exe", "type": "Game" }
+{ "name": "KissMeEveryday.exe", "type": "Game" }
+{ "name": "KissMeEveryday-HD.exe", "type": "Game" }
+
 # Maitetsu:Last Run!! https://store.steampowered.com/app/1434480/MaitetsuLast_Run/
 { "name": "MaitetsuLastRun.exe", "type": "Game" }
 
@@ -486,6 +491,9 @@
 
 # Merge Adventure: Magic Dragons https://store.steampowered.com/app/2495050/Merge_Adventure_Magic_Dragons/
 { "name": "Merge Adventure.exe", "type": "Game" }
+
+# Mesen N******* multi-emulator via wine for SDL2 mouse keys https://www.mesen.ca/
+{ "name": "Mesen.exe", "type": "Game" }
 
 # Metal Bringer https://store.steampowered.com/app/2334170/Metal_Bringer/
 { "name": "MetalBringer.exe", "type": "Game" }

--- a/00-default/Games/wine_proton/wine_proton_n.rules
+++ b/00-default/Games/wine_proton/wine_proton_n.rules
@@ -8,6 +8,9 @@
 # nail'd https://store.steampowered.com/app/40380/naild/
 { "name": "Naild_x86.exe", "type": "Game" }
 
+# Naisho No Jikan https://www.myabandonware.com/game/naisho-no-jikan-109u
+{ "name": "naisho.exe", "type": "Game" }
+
 # NAMCO MUSEUM ARCHIVES Vol 1 https://store.steampowered.com/app/1250250/NAMCO_MUSEUM_ARCHIVES_Vol_1/
 { "name": "NMA1.exe", "type": "Game"}
 

--- a/00-default/Games/wine_proton/wine_proton_o.rules
+++ b/00-default/Games/wine_proton/wine_proton_o.rules
@@ -164,6 +164,9 @@
 # One Way Heroics https://store.steampowered.com/app/266210/One_Way_Heroics/
 { "name": "Game_Normal.exe", "type": "Game" }
 
+# Onii Kiss https://nekonyansoft.com/blog/saving-the-sisters-announcing-onikiss-re-release
+{ "name": "OniiKiss.exe", "type": "Game" }
+
 # Onimusha 2: Samurai's Destiny https://store.steampowered.com/app/3046600/Onimusha_2_Samurais_Destiny/
 { "name": "Onimusha2.exe", "type": "Game" }
 


### PR DESCRIPTION
Just added 3 VNs and new emulator for IBM clones: 86Box. Also re-added Mesen as via wine, for those who use extra mouse keys to play some N******* games, allowing better control with more key remaps, this was necessary due to SDL2 for Linux limitations.