### PR TITLE
Add Manicraft Bedrock Launcher entries to rules

### DIFF
--- a/00-default/Games/linux-native/linux-native_m.rules
+++ b/00-default/Games/linux-native/linux-native_m.rules
@@ -112,6 +112,10 @@
 # Mindustry https://store.steampowered.com/app/1127400/Mindustry/
 { "name": "Mindustry", "type": "Game" }
 
+# Manicraft Bedrock Launcher https://minecraft-linux.github.io
+{ "name": "mcpelauncher-ui-qt", "type": "Game" }
+{ "name": "mcpelauncher-client", "type": "Game" }
+
 # Mini Airways https://store.steampowered.com/app/2289650/Mini_Airways__ATC_simulator/
 { "name": "MiniAirways.x86_64", "type": "Game" }
 


### PR DESCRIPTION
The Unofficial *NIX Lancher for Minecraft is an unofficial launcher for the Android version the Minecraft Bedrock Edition. It uses uses fake JNI (Java Native Interface) to communicate with Minecraft. Unofficial *NIX Lancher for Minecraft supports x86_64 and arm64 versions of Minecraft on both Linux and MacOS. (The package are available both native and flatpak)