### PR TITLE
Add games and More

### DIFF
--- a/00-default/Games/wine_proton/common.rules
+++ b/00-default/Games/wine_proton/common.rules
@@ -336,6 +336,10 @@
 # Onimusha: Warlords https://store.steampowered.com/app/761600/
 # SRPG Studio https://store.steampowered.com/app/857320/SRPG_Studio/
 # SoulSaverOnline https://store.steampowered.com/app/542590/SoulSaverOnline/
+# Zhū tiān shuā bǎo lù 诸天刷宝录 https://store.steampowered.com/app/2776450/Multiverse_Loot_Hunter/
+# Xīngjì gōngyèguó 星际工业国 https://store.steampowered.com/app/2423620/Space_industrial_empire/
+# Tūnshí kǒngmíng chuán Tunshi Kongming Legends 吞食孔明传 Tunshi Kongming Legends https://store.steampowered.com/app/929200/_Tunshi_Kongming_Legends/
+# Xiūxiān lìzhì chuán 修仙立志传 https://store.steampowered.com/app/1649730/xiuzhen_idle/
 { "name": "game.exe", "type": "Game" }
 
 # STEINS;GATE 0 https://store.steampowered.com/app/825630/STEINSGATE_0/
@@ -396,6 +400,9 @@
 # LISA https://store.steampowered.com/app/335670/LISA_The_Painful/
 # Tales of the Black Forest https://store.steampowered.com/app/1093910/Tales_of_the_Black_Forest/
 # Star Knightess Aura https://store.steampowered.com/app/1827650/Star_Knightess_Aura/
+# Zài shuā yī bǎ PlayAgain 再刷一把 PlayAgain https://store.steampowered.com/app/2059790/_PlayAgain/
+# Shuā a shuā 刷啊刷 https://store.steampowered.com/app/2897560/_/
+# Gōng shàng líng xiāo bǎodiàn 攻上凌霄宝殿 https://store.steampowered.com/app/3578480/_/
 { "name": "Game.exe", "type": "Game" }
 
 # Star Trek Online https://store.steampowered.com/app/9900/Star_Trek_Online/
@@ -623,6 +630,10 @@
 
 # Sānguó qúnyīng chuán 三国群英传2 https://store.steampowered.com/app/1437830/Heroes_of_the_Three_Kingdoms_2/
 # Heroes of the Three Kingdoms 7 https://store.steampowered.com/app/1437880/Heroes_of_the_Three_Kingdoms_7/
+# Sānguó qúnyīng chuán 三国群英传 https://store.steampowered.com/app/1437820/Heroes_of_the_Three_Kingdoms/
+# Sānguó qúnyīng chuán 3 三国群英传3 https://store.steampowered.com/app/1437840/Heroes_of_the_Three_Kingdoms_3/
+# Sānguó qúnyīng chuán 5 三国群英传5 https://store.steampowered.com/app/1437860/Heroes_of_the_Three_Kingdoms_5/
+# Sānguó qúnyīng chuán 6 三国群英传6 https://store.steampowered.com/app/1437870/Heroes_of_the_Three_Kingdoms_6/
 { "name": "LaunchSango.exe", "type": "Game" }
 
 # Life is Strange: Before the Storm https://store.steampowered.com/app/554620/Life_is_Strange_Before_the_Storm/

--- a/00-default/Games/wine_proton/wine_proton_non-latin.rules
+++ b/00-default/Games/wine_proton/wine_proton_non-latin.rules
@@ -47,9 +47,6 @@
 # Fù jiǎ tiānxià 5 富甲天下5 https://store.steampowered.com/app/2490910/5/
 { "name": "M3K5.exe", "type": "Game" }
 
-# Gōng shàng líng xiāo bǎodiàn 攻上凌霄宝殿 https://store.steampowered.com/app/3578480/_/
-{ "name": "Game.exe", "type": "Game" }
-
 # Guà jī èmó/IdleDevils 挂姬恶魔/IdleDevils https://store.steampowered.com/app/2226700/_IDLE_DEVILS/
 { "name": "IdleDevils.exe", "type": "Game" }
 
@@ -135,23 +132,19 @@
 { "name": "Poq.exe", "type": "Game" }
 
 # Sānguó qúnyīng chuán 三国群英传 https://store.steampowered.com/app/1437820/Heroes_of_the_Three_Kingdoms/
-{ "name": "LaunchSango.exe", "type": "Game" }
-{ "name": "SGConfig.exe", "type": "Game" }
+{ "name": "Sango.exe", "type": "Game" }
 
 # Sānguó qúnyīng chuán 三国群英传2 https://store.steampowered.com/app/1437830/Heroes_of_the_Three_Kingdoms_2/
 { "name": "Sango2.exe", "type": "Game" }
 
 # Sānguó qúnyīng chuán 3 三国群英传3 https://store.steampowered.com/app/1437840/Heroes_of_the_Three_Kingdoms_3/
-{ "name": "LaunchSango.exe", "type": "Game" }
-{ "name": "SGConfig.exe", "type": "Game" }
+{ "name": "Sango3.exe", "type": "Game" }
 
 # Sānguó qúnyīng chuán 5 三国群英传5 https://store.steampowered.com/app/1437860/Heroes_of_the_Three_Kingdoms_5/
-{ "name": "LaunchSango.exe", "type": "Game" }
-{ "name": "SGConfig.exe", "type": "Game" }
+{ "name": "Sango5.exe", "type": "Game" }
 
 # Sānguó qúnyīng chuán 6 三国群英传6 https://store.steampowered.com/app/1437870/Heroes_of_the_Three_Kingdoms_6/
-{ "name": "LaunchSango.exe", "type": "Game" }
-{ "name": "SGConfig.exe", "type": "Game" }
+{ "name": "Sango6.exe", "type": "Game" }
 
 # Sānguó qúnyīng chuán 三国群英传8 Kingdom Heroes 8 https://store.steampowered.com/app/875210/Kingdom_Heroes_8/
 { "name": "SG8.exe", "type": "Game" }
@@ -171,9 +164,6 @@
 
 # Shǒu bàn màoxiǎn tuán 手办冒险团 https://steamdb.info/app/2996570/
 { "name": "GNSBT.exe", "type": "Game" }
-
-# Shuā a shuā 刷啊刷 https://store.steampowered.com/app/2897560/_/
-{ "name": "Game.exe", "type": "Game" }
 
 # “Shǔshān: Chū zhāng” mǎi duàn bǎn《蜀山：初章》买断版 https://store.steampowered.com/app/1461810/_/
 { "name": "ShuShan.exe", "type": "Game" }
@@ -198,9 +188,6 @@
 # Tuī bì yǒngzhě 推币勇者 https://store.steampowered.com/app/3036010/Coin_Push_RPG/
 { "name": "CoinPushRPG.exe", "type": "Game" }
 { "name": "CoinPushRPG-Win64-Shipping.exe", "type": "Game" }
-
-# Tūnshí kǒngmíng chuán Tunshi Kongming Legends 吞食孔明传 Tunshi Kongming Legends https://store.steampowered.com/app/929200/_Tunshi_Kongming_Legends/
-{ "name": "game.exe", "type": "Game" }
 
 # Wǒ láizì jiānghú 我来自江湖 https://store.steampowered.com/app/1058770/_From_Jianghu/
 { "name": "FromJianghu.exe", "type": "Game" }
@@ -234,9 +221,6 @@
 # Xiá zhī dào (PathOfWuxia) 俠之道(PathOfWuxia) https://store.steampowered.com/app/1189630/Path_Of_Wuxia/
 { "name": "PathOfWuxia.exe", "type": "Game" }
 
-# Xīngjì gōngyèguó 星际工业国 https://store.steampowered.com/app/2423620/Space_industrial_empire/
-{ "name": "game.exe", "type": "Game" }
-
 # Xīng mèng guǐjì Star Dream Journey 星梦轨迹 Star Dream Journey https://store.steampowered.com/app/3373900/Star_Dream_Journey/
 { "name": "xmgj.exe", "type": "Game" }
 
@@ -250,9 +234,6 @@
 # Xiūxiān: Dàn xìtǒng ràng wǒ zhòngtián 修仙：但系统让我种田 https://store.steampowered.com/app/3060630/Immortal_Farmer_Systems_Mandate/
 { "name": "Immortal.exe", "type": "Game" }
 
-# Xiūxiān lìzhì chuán 修仙立志传 https://store.steampowered.com/app/1649730/xiuzhen_idle/
-{ "name": "game.exe", "type": "Game" }
-
 # Yì jiàn jiānghú 奕剑江湖 https://store.steampowered.com/app/2701510/_/
 { "name": "JungleGame-Win64-Shipping.exe", "type": "Game" }
 { "name": "JungleGame.exe", "type": "Game" }
@@ -262,9 +243,6 @@
 
 # yuè yuán zhī yè 月圆之夜 (Night of Full Moon) https://store.steampowered.com/app/769560/_Night_of_Full_Moon/
 { "name": "Night of the Full Moon.exe", "type": "Game" }
-
-# Zài shuā yī bǎ PlayAgain 再刷一把 PlayAgain https://store.steampowered.com/app/2059790/_PlayAgain/
-{ "name": "Game.exe", "type": "Game" }
 
 # Zhǎn yāo xíng 斩妖行 Eastern Exorcist https://store.steampowered.com/app/1120810/Eastern_Exorcist/
 { "name": "Exorcist.exe", "type": "Game" }
@@ -280,9 +258,6 @@
 
 # zhuō miàn Ko Nekomusume 桌面小猫娘 https://store.steampowered.com/app/3449850/Desktop_Kitten_Girl/
 { "name": "Desktop Kitten Girl.exe", "type": "Game" }
-
-# Zhū tiān shuā bǎo lù 诸天刷宝录 https://store.steampowered.com/app/2776450/Multiverse_Loot_Hunter/
-{ "name": "game.exe", "type": "Game" }
 
 # Zuìhòu de xiūxiān zhě 最后的修仙者 https://store.steampowered.com/app/3486240/_/
 { "name": "the last immortals.exe", "type": "Game" }

--- a/00-default/Games/wine_proton/wine_proton_non-latin.rules
+++ b/00-default/Games/wine_proton/wine_proton_non-latin.rules
@@ -5,6 +5,35 @@
 
 ### Chinese ###
 
+# Amatsuki mājan 天月麻雀 https://store.steampowered.com/app/3132860/_Amatsuki_Mahjong/
+{ "name": "mahjongP.exe", "type": "Game" }
+
+# Bēng jìng huíshōu zhàn 嘣境回收战 https://store.steampowered.com/app/2411910/miniBONG/
+{ "name": "miniBONG.exe", "type": "Game" }
+
+# Chénmò de xīshuài 沉默的蟋蟀 https://store.steampowered.com/app/2216130/_/
+{ "name": "Cricket.exe", "type": "Game" }
+
+# Dà jiānghú zhī cānglóng yǔ bái niǎo 大江湖之苍龙与白鸟 https://store.steampowered.com/app/1407450/The_World_of_Kungfu_Dragon_and_Eagle/
+{ "name": "TheWorldOfKongFu.exe", "type": "Game" }
+
+# Dié: Jīngzhé 谍：惊蛰 https://store.steampowered.com/app/2374000/Insects_Awaken/
+{ "name": "Awaken.exe", "type": "Game" }
+
+# Dì xīn guītú Return From Core 地心归途 Return From Core https://store.steampowered.com/app/2171630/Return_from_Core/
+{ "name": "Return From Core.exe", "type": "Game" }
+
+# Dōngfāng guāngyào yè ~ Lost Branch of Legend 东方光耀夜 ~ Lost Branch of Legend https://store.steampowered.com/app/1140150/Touhou_Lost_Branch_of_Legend/
+{ "name": "ModTheLBoL.Desktop.exe", "type": "Game" }
+{ "name": "LBoL.exe", "type": "Game" }
+
+# Dōngfāng: Píngyě gū hóng 东方：平野孤鸿 https://store.steampowered.com/app/2656540/Ballads_of_Hongye_REBORN/
+{ "name": "BalladsOfHongye.exe", "type": "Game" }
+
+# Fēitiān lìxiǎn guójì zhōngwén bǎn 飛天歷險國際中文版 https://store.steampowered.com/app/1920770/Dream_Of_Mirror_Online/
+{ "name": "DOMO_Steam.exe", "type": "Game" }
+{ "name": "DOMO.exe", "type": "Game" }
+
 # fēng líng dàng àn 封灵档案 https://store.steampowered.com/app/1520470/Soul_Dossier/
 { "name": "NotesOfSoulServer-Win64-Shipping.exe", "type": "Game" }
 
@@ -12,36 +41,127 @@
 { "name": "fxl.exe", "type": "Game" }
 { "name": "fxl-32.exe", "type": "Game" }
 
+# Fù jiǎ tiānxià 4 富甲天下4 https://store.steampowered.com/app/2400280/4/
+{ "name": "M3K4.exe", "type": "Game" }
+
+# Fù jiǎ tiānxià 5 富甲天下5 https://store.steampowered.com/app/2490910/5/
+{ "name": "M3K5.exe", "type": "Game" }
+
+# Gōng shàng líng xiāo bǎodiàn 攻上凌霄宝殿 https://store.steampowered.com/app/3578480/_/
+{ "name": "Game.exe", "type": "Game" }
+
+# Guà jī èmó/IdleDevils 挂姬恶魔/IdleDevils https://store.steampowered.com/app/2226700/_IDLE_DEVILS/
+{ "name": "IdleDevils.exe", "type": "Game" }
+
+# Guàjī shénhuà 挂机神话 https://store.steampowered.com/app/1863750/_/
+{ "name": "GuaJiShenHua.exe", "type": "Game" }
+
+# Guàjī yītiáo jiē 挂机一条街 https://store.steampowered.com/app/1476360/Hang_up_Street/
+{ "name": "mini_guaji.exe", "type": "Game" }
+
 # guǐ gǔ bā huāng 鬼谷八荒 Tale of Immortal https://store.steampowered.com/app/1468810/_Tale_of_Immortal/
 { "name": "guigubahuang.exe", "type": "Game" }
+
+# Gǔ jiàn qí tán èr 古剑奇谭二(GuJian2) https://store.steampowered.com/app/570770/GuJian2/
+{ "name": "GuJian2.exe", "type": "Game" }
 
 # Gǔ jiàn qí tán 古剑奇谭(GuJian) https://store.steampowered.com/app/570780/GuJian/
 { "name": "GuJian.exe", "type": "Game" }
 { "name": "GuJianConfigTool.exe", "type": "Game" }
 
-# Gǔ jiàn qí tán èr 古剑奇谭二(GuJian2) https://store.steampowered.com/app/570770/GuJian2/
-{ "name": "GuJian2.exe", "type": "Game" }
+# Gǔlóng fēngyún lù 古龙风云录 https://store.steampowered.com/app/2340650/_/
+{ "name": "GuLong.exe", "type": "Game" }
+
+# Hǎi shā fēngyún Far Away 海沙风云 Far Away https://store.steampowered.com/app/1250760/Far_Away/
+{ "name": "海沙风云.exe", "type": "Game" }
+
+# Hàn chén: Fǔ cǎo wéi yíng 汉尘：腐草为萤 https://store.steampowered.com/app/2078910/_/
+{ "name": "HanChen.exe", "type": "Game" }
+
+# Hé luò qún xiá chuán (Ho Tu Lo Shu: The Books of Dragon) 河洛群俠傳 (Ho Tu Lo Shu ： The Books of Dragon) https://store.steampowered.com/app/952860/_Ho_Tu_Lo_Shu__The_Books_of_Dragon/
+{ "name": "J2.exe", "type": "Game" }
+
+# Huáng máo piāoliú jì 黄毛漂流记 https://store.steampowered.com/app/2535770/_/
+{ "name": "UninhabitedIsland.exe", "type": "Game" }
 
 # Jiāngchéng chuàngyè jì 江城创业记 River Town Factory https://store.steampowered.com/app/2281410/River_Town_Factory/
 { "name": "jcGame.exe", "type": "Game" }
 
+# Jiānghú kèzhàn-wújìn lúnhuí 江湖客栈-无尽轮回 https://store.steampowered.com/app/1881610/The_Jianghu/
+{ "name": "jianghukezhan.exe", "type": "Game" }
+
+# Jiàng yāo sǎnjì 降妖散记 https://store.steampowered.com/app/1915510/YaoGuai_Hunter/
+{ "name": "降妖散记.exe", "type": "Game" }
+
+# Juézhàn zǐ jìn huáijiù fú 决战紫禁怀旧服 https://store.steampowered.com/app/2148830/_/
+{ "name": "决战紫禁怀旧服.exe", "type": "Game" }
+
+# Kāijú yī bǎ jiàn 开局一把剑 https://store.steampowered.com/app/1355440/_/
+{ "name": "开局一把剑.exe", "type": "Game" }
+
+# Lǎn rén xiūxiān chuán 懒人修仙传 https://store.steampowered.com/app/892420/_/
+{ "name": "懒人修仙传.exe", "type": "Game" }
+
+# Lǎn rén xiūxiān chuán 2 懒人修仙传2 https://store.steampowered.com/app/1266630/2/
+{ "name": "LanRen2.exe", "type": "Game" }
+
+# Líng shòu jiānghú 灵兽江湖 https://store.steampowered.com/app/2232880/Beast_Saga/
+{ "name": "BeastSaga.exe", "type": "Game" }
+
 # lóng yìn lì zhì chuán 龙胤立志传 https://store.steampowered.com/app/3202030/_/
 { "name": "LongYinLiZhiZhuan.exe", "type": "Game" }
+
+# Měinǚ, qǐng bié yǐngxiǎng wǒ xuéxí 美女，请别影响我学习 https://store.steampowered.com/app/2786680/Knowledge_or_know_Lady/
+{ "name": "LSPGame.exe", "type": "Game" }
+{ "name": "Game_Win.exe", "type": "Game" }
 
 # mì cháng shēng 觅长生 https://store.steampowered.com/app/1189490/_/
 { "name": "觅长生.exe", "type": "Game" }
 
+# Mónǐ dìguó 模拟帝国 https://store.steampowered.com/app/1041710/Sim_Empire/
+{ "name": "Sim Empire.exe", "type": "Game" }
+
 # mó nǚ de yè yàn 魔女的夜宴 https://store.steampowered.com/app/2458530/_/
 { "name": "SabbatOfTheWitch.exe", "type": "Game" }
+
+# Mukyū Sen to/ EndlessJourney 無休仙途/EndlessJourney https://store.steampowered.com/app/2654540/_/
+{ "name": "WuXiuXianTu.exe", "type": "Game" }
 
 # nuǎn xuě 暖雪 Warm Snow https://store.steampowered.com/app/1296830/_Warm_Snow/
 { "name": "WarmSnow.exe", "type": "Game" }
 
+# Qín shāng 秦殇 https://store.steampowered.com/app/970500/_Prince_of_Qin/
+{ "name": "POQ.exe", "type": "Game" }
+{ "name": "Poq.exe", "type": "Game" }
+
+# Sānguó qúnyīng chuán 三国群英传 https://store.steampowered.com/app/1437820/Heroes_of_the_Three_Kingdoms/
+{ "name": "LaunchSango.exe", "type": "Game" }
+{ "name": "SGConfig.exe", "type": "Game" }
+
 # Sānguó qúnyīng chuán 三国群英传2 https://store.steampowered.com/app/1437830/Heroes_of_the_Three_Kingdoms_2/
 { "name": "Sango2.exe", "type": "Game" }
 
+# Sānguó qúnyīng chuán 3 三国群英传3 https://store.steampowered.com/app/1437840/Heroes_of_the_Three_Kingdoms_3/
+{ "name": "LaunchSango.exe", "type": "Game" }
+{ "name": "SGConfig.exe", "type": "Game" }
+
+# Sānguó qúnyīng chuán 5 三国群英传5 https://store.steampowered.com/app/1437860/Heroes_of_the_Three_Kingdoms_5/
+{ "name": "LaunchSango.exe", "type": "Game" }
+{ "name": "SGConfig.exe", "type": "Game" }
+
+# Sānguó qúnyīng chuán 6 三国群英传6 https://store.steampowered.com/app/1437870/Heroes_of_the_Three_Kingdoms_6/
+{ "name": "LaunchSango.exe", "type": "Game" }
+{ "name": "SGConfig.exe", "type": "Game" }
+
 # Sānguó qúnyīng chuán 三国群英传8 Kingdom Heroes 8 https://store.steampowered.com/app/875210/Kingdom_Heroes_8/
 { "name": "SG8.exe", "type": "Game" }
+
+# Shānmén yǔ huànjìng (The Lost Village) 山门与幻境（The Lost Village） https://store.steampowered.com/app/1963040/The_Lost_Village/
+{ "name": "TheLostVillage.exe", "type": "Game" }
+{ "name": "TheLostVillage-Win64-Shipping.exe", "type": "Game" }
+
+# Shàonǚ de yídòng chéngbǎo 少女的移动城堡 https://store.steampowered.com/app/2850220/The_Girls_Moving_Castle/
+{ "name": "少女的移动城堡.exe", "type": "Game" }
 
 # Shén dōu bùliáng tàn 神都不良探 Underdog Detective https://store.steampowered.com/app/1681970/_Underdog_Detective/
 { "name": "Luoyang.exe", "type": "Game" }
@@ -49,11 +169,102 @@
 # Shì xiě yìn 嗜血印 Bloody Spell https://store.steampowered.com/app/992300/_Bloody_Spell/
 { "name": "BloodySpell.exe", "type": "Game" }
 
+# Shǒu bàn màoxiǎn tuán 手办冒险团 https://steamdb.info/app/2996570/
+{ "name": "GNSBT.exe", "type": "Game" }
+
+# Shuā a shuā 刷啊刷 https://store.steampowered.com/app/2897560/_/
+{ "name": "Game.exe", "type": "Game" }
+
+# “Shǔshān: Chū zhāng” mǎi duàn bǎn《蜀山：初章》买断版 https://store.steampowered.com/app/1461810/_/
+{ "name": "ShuShan.exe", "type": "Game" }
+{ "name": "ShuShan-Win64-Shipping.exe", "type": "Game" }
+
+# Tenmei ki o feito shīkā 天命奇御 Fate Seeker https://store.steampowered.com/app/882790/Fate_Seeker/
+{ "name": "Fate Seeker Journey.exe", "type": "Game" }
+{ "name": "FateSeeker.exe", "type": "Game" }
+
+# Tenmei ki o ni feito shīkā II 天命奇御二 Fate Seeker II https://store.steampowered.com/app/1559390/Fate_Seeker_II/
+{ "name": "FateSeekerII.exe", "type": "Game" }
+
+# Tiānxià bà tú 天下霸圖 https://store.steampowered.com/app/2304030/_/
+{ "name": "MKSteam.exe", "type": "Game" }
+
+# Tiěqí shàonǚ (Cavalry Girls) 铁骑少女（Cavalry Girls） https://store.steampowered.com/app/2055050/
+{ "name": "CavalryGirls.exe", "type": "Game" }
+
+# Tōng shén bǎng Noobs Want to Live 通神榜 Noobs Want to Live https://store.steampowered.com/app/1737340/Noobs_Want_to_Live/
+{ "name": "Noobs Want To Live.exe", "type": "Game" }
+
+# Tuī bì yǒngzhě 推币勇者 https://store.steampowered.com/app/3036010/Coin_Push_RPG/
+{ "name": "CoinPushRPG.exe", "type": "Game" }
+{ "name": "CoinPushRPG-Win64-Shipping.exe", "type": "Game" }
+
+# Tūnshí kǒngmíng chuán Tunshi Kongming Legends 吞食孔明传 Tunshi Kongming Legends https://store.steampowered.com/app/929200/_Tunshi_Kongming_Legends/
+{ "name": "game.exe", "type": "Game" }
+
+# Wǒ láizì jiānghú 我来自江湖 https://store.steampowered.com/app/1058770/_From_Jianghu/
+{ "name": "FromJianghu.exe", "type": "Game" }
+
+# Wú zuì zhī tíng/Trials of Innocence 无罪之庭/Trials of Innocence https://store.steampowered.com/app/2983140/Trials_of_Innocence/
+{ "name": "Trials of Innocence.exe", "type": "Game" }
+
+# Xiákè fēngyún chuán (Tale of Wuxia) 侠客风云传(Tale of Wuxia) https://store.steampowered.com/app/377530/Tale_of_Wuxia/
+{ "name": "wuxia.exe", "type": "Game" }
+
+# Xián yú de guàjī yóuxì 咸鱼的挂机游戏 https://store.steampowered.com/app/1815370/_/
+{ "name": "咸鱼的挂机游戏快餐版.exe", "type": "Game" }
+{ "name": "咸鱼的挂机游戏.exe", "type": "Game" }
+{ "name": "咸鱼的挂机游戏(English).exe", "type": "Game" }
+
+# Xián yú diànxià 咸鱼殿下 https://store.steampowered.com/app/3433810/__My_journey/
+{ "name": "MyJourneyStory.exe", "type": "Game" }
+
+# Xiǎo hēi hé jiāsùqì 小黑盒加速器 https://store.steampowered.com/app/1447430/_/
+{ "name": "heyboxacc.exe", "type": "Game" }
+
+# Xiāoshī de hángbān, hái yǒu tā tā tā!Lost in the secret! 消失的航班，还有她她她！Lost in the secret! https://store.steampowered.com/app/3418690/Lost_in_the_secret/
+{ "name": "LostInTheSecret_GameMake_Import.exe", "type": "Game" }
+
+# Xiǎo xiǎo xiákè mónǐ qì 小小侠客模拟器 https://store.steampowered.com/app/3395140/_/
+{ "name": "MiniMartialWorld.exe", "type": "Game" }
+
 # xià yī zhàn jiāng hú Ⅱ 下一站江湖Ⅱ https://store.steampowered.com/app/1606180/II/
 { "name": "下一站江湖Ⅱ.exe", "type": "Game" }
 
+# Xiá zhī dào (PathOfWuxia) 俠之道(PathOfWuxia) https://store.steampowered.com/app/1189630/Path_Of_Wuxia/
+{ "name": "PathOfWuxia.exe", "type": "Game" }
+
+# Xīngjì gōngyèguó 星际工业国 https://store.steampowered.com/app/2423620/Space_industrial_empire/
+{ "name": "game.exe", "type": "Game" }
+
+# Xīng mèng guǐjì Star Dream Journey 星梦轨迹 Star Dream Journey https://store.steampowered.com/app/3373900/Star_Dream_Journey/
+{ "name": "xmgj.exe", "type": "Game" }
+
+# Xīng yuán yí jìng 星源遗境 https://store.steampowered.com/app/2877480/StarArc_Echo/
+{ "name": "StarArc_Echo.exe", "type": "Game" }
+{ "name": "StarArc_Echo-Win64-Shipping.exe", "type": "Game" }
+
+# Xiūliàn chéng xiān 修炼成仙 https://store.steampowered.com/app/2547120/_/
+{ "name": "xlcx.exe", "type": "Game" }
+
+# Xiūxiān: Dàn xìtǒng ràng wǒ zhòngtián 修仙：但系统让我种田 https://store.steampowered.com/app/3060630/Immortal_Farmer_Systems_Mandate/
+{ "name": "Immortal.exe", "type": "Game" }
+
+# Xiūxiān lìzhì chuán 修仙立志传 https://store.steampowered.com/app/1649730/xiuzhen_idle/
+{ "name": "game.exe", "type": "Game" }
+
+# Yì jiàn jiānghú 奕剑江湖 https://store.steampowered.com/app/2701510/_/
+{ "name": "JungleGame-Win64-Shipping.exe", "type": "Game" }
+{ "name": "JungleGame.exe", "type": "Game" }
+
+# Yǒnggǎn de hā kè (HAAK) 勇敢的哈克（HAAK） https://store.steampowered.com/app/1352930/HAAK/
+{ "name": "haak.exe", "type": "Game" }
+
 # yuè yuán zhī yè 月圆之夜 (Night of Full Moon) https://store.steampowered.com/app/769560/_Night_of_Full_Moon/
 { "name": "Night of the Full Moon.exe", "type": "Game" }
+
+# Zài shuā yī bǎ PlayAgain 再刷一把 PlayAgain https://store.steampowered.com/app/2059790/_PlayAgain/
+{ "name": "Game.exe", "type": "Game" }
 
 # Zhǎn yāo xíng 斩妖行 Eastern Exorcist https://store.steampowered.com/app/1120810/Eastern_Exorcist/
 { "name": "Exorcist.exe", "type": "Game" }
@@ -61,17 +272,56 @@
 # zhèn xié  镇邪 https://store.steampowered.com/app/1939560/_/
 { "name": "ZX.exe", "type": "Game" }
 
+# Zhōnghuá yī shāng: Chuánchéng 中华一商：传承 https://store.steampowered.com/app/3261010/East_Trade_Tycoon_Inheritance/
+{ "name": "EastTradeTycoon.exe", "type": "Game" }
+
+# Zhúlù 逐鹿 https://store.steampowered.com/app/1984720/_/
+{ "name": "逐鹿.exe", "type": "Game" }
+
+# zhuō miàn Ko Nekomusume 桌面小猫娘 https://store.steampowered.com/app/3449850/Desktop_Kitten_Girl/
+{ "name": "Desktop Kitten Girl.exe", "type": "Game" }
+
+# Zhū tiān shuā bǎo lù 诸天刷宝录 https://store.steampowered.com/app/2776450/Multiverse_Loot_Hunter/
+{ "name": "game.exe", "type": "Game" }
+
+# Zuìhòu de xiūxiān zhě 最后的修仙者 https://store.steampowered.com/app/3486240/_/
+{ "name": "the last immortals.exe", "type": "Game" }
+
 
 ### Japanese ### 
 
-# Uma musume puritīdābī ウマ娘 プリティーダービー https://steamdb.info/app/3564400/
-{ "name": "UmamusumePrettyDerby_Jpn.exe", "type": "Game" }
+# Hideodensetsu Sō no kiseki 英雄伝説 創の軌跡 https://store.steampowered.com/app/1562940/THE_LEGEND_OF_HEROES_HAJIMARI_NO_KISEKI/
+{ "name": "ed8_ps5_D3D11.exe", "type": "Game" }
+{ "name": "GameConfig.exe", "type": "Game" }
+
+# Hororaibu otakara maunten ホロライブお宝マウンテン https://store.steampowered.com/app/2972990/hololive_Treasure_Mountain/
+{ "name": "TreasureMountain.exe", "type": "Game" }
+
+# Iru dō イル・ドー https://store.steampowered.com/app/3561770/Irudo/
+{ "name": "Irudo.exe", "type": "Game" }
+{ "name": "Pirate_Island.exe", "type": "Game" }
+{ "name": "Pirate_Island-Win64-Shipping.exe", "type": "Game" }
+
+# Kanji de GO! Shūeisha manga-sai 漢字でGO! 集英社マンガ祭 https://store.steampowered.com/app/3350140/GO/
+{ "name": "集英社マンガ祭.exe", "type": "Game" }
+
+# Natsume yūjinchō ~ hadzuki no ki ~ 夏目友人帳 ～葉月の記～ https://store.steampowered.com/app/3344960/_/
+{ "name": "Natsume Yujincho.exe", "type": "Game" }
+
+# Rabu raibu! Niji ~ke Saki gakuen sukūruaidoru dōkō-kai tokimeki no mirai chizu ラブライブ！虹ヶ咲学園スクールアイドル同好会　トキメキの未来地図 https://store.steampowered.com/app/3213690/Love_Live_Nijigasaki_High_School_Idol_Club_TOKIMEKI_Roadmap_to_Future/
+{ "name": "nijichizu.exe", "type": "Game" }
 
 # Sutā sora itofantajī ~ sora e todoku mahō ~ スターそらイトファンタジー　～空へ届く魔法～ https://store.steampowered.com/app/3668950/Star_Soraight_Fantasy_Magic_to_reach_the_sky/
 { "name": "StarSoraightFantasy.exe", "type": "Game" }
 
 # Tsuki ni yori-sō otome no sahō 月に寄りそう乙女の作法 https://store.steampowered.com/app/1776970/_/
 { "name": "Tsukiniyorisou.exe", "type": "Game" }
+
+# Uma musume puritīdābī ウマ娘 プリティーダービー https://steamdb.info/app/3564400/
+{ "name": "UmamusumePrettyDerby_Jpn.exe", "type": "Game" }
+
+# Wārudonebārando erunea ōkoku no hibi ワールドネバーランド　エルネア王国の日々　Another Life Adventure https://store.steampowered.com/app/3034340/
+{ "name": "WorldNeverland.exe", "type": "Game" }
 
 
 ### Russian ###

--- a/sort-games.sh
+++ b/sort-games.sh
@@ -4,7 +4,12 @@
 # don't use this script to sort common.rules and non-latin rules
 # use it to sort files "from a to z", "the" and numerical
 
-# Usage: ./sort_elements.sh wine_proton_a.rules
+# experimental: script can also sort japanese/chinese entries. requires perl.
+# to sort chinese/japanese entries they should have pinyin(for chinese) and romaji (for japanese) as prefix (see examples in wine_proton_non-latin.rules)
+# Make a temporary file, for example chinese.rules and move entries there after the sort move entries back to corresponding file
+# Usage: ./sort-games.sh use-diacritics chinese.rules
+
+# Usage: ./sort-games.sh wine_proton_a.rules
 #
 # Usage to sort multiple files with single command (a to z) numerical and the. run this script in the root of the repo
 # 
@@ -19,6 +24,7 @@
 
 parse_and_sort() {
     local file="$1"
+    local use_diacritics="$2"
     local -A ids names jsons
     local current_id="" current_name="" current_jsons=""
 
@@ -39,7 +45,11 @@ parse_and_sort() {
 
     make_id() {
         local title="$1"
-        echo "$title" | sed 's/http.*//' | sed 's/[^a-zA-Z0-9 ]//g' | tr -d ' ' | tr '[:upper:]' '[:lower:]'
+        if [[ -n "$use_diacritics" ]]; then
+            echo "$title" | sed 's/https\?:[^ ]*//' | perl -CSD -pe 's/[^\x{0000}-\x{024F} ]//g; s/[^a-zA-Z0-9\x{00C0}-\x{024F} ]//g' | tr '[:upper:]' '[:lower:]' | tr -d ' '
+        else
+            echo "$title" | sed 's/http.*//' | sed 's/[^a-zA-Z0-9 ]//g' | tr -d ' ' | tr '[:upper:]' '[:lower:]'
+        fi
     }
 
     is_header_line() {
@@ -102,4 +112,8 @@ parse_and_sort() {
     printf '%s' "${output%$'\n'}" > "$file"
 }
 
-parse_and_sort "${1}"
+if [[ "$1" == "use-diacritics" ]]; then
+    parse_and_sort "$2" "1"
+else
+    parse_and_sort "$1" ""
+fi


### PR DESCRIPTION
this was annoying...
The More: added experimental sort functionality for chinese/japanese entries
check comments in sort file to learn how to use it. @pollux78 

### Games ###
模拟帝国
我来自江湖
开局一把剑
勇敢的哈克（HAAK）
大江湖之苍龙与白鸟
三国群英传
三国群英传3
三国群英传5
三国群英传6
黄毛漂流记
星源遗境
刷啊刷
無休仙途/EndlessJourney
东方：平野孤鸿
奕剑江湖
诸天刷宝录
美女，请别影响我学习
少女的移动城堡
修炼成仙
天下霸圖
古龙风云录
嘣境回收战
星际工业国
富甲天下4
谍：惊蛰
沉默的蟋蟀
挂姬恶魔/IdleDevils
灵兽江湖
小黑盒加速器
决战紫禁怀旧服
地心归途 Return From Core
《蜀山：初章》买断版
挂机一条街
ワールドネバーランド　エルネア王国の日々　Another Life Adventure
夏目友人帳 ～葉月の記～
河洛群俠傳 (Ho Tu Lo Shu ： The Books of Dragon)
秦殇
漢字でGO! 集英社マンガ祭
星梦轨迹 Star Dream Journey
天命奇御 Fate Seeker
懒人修仙传
小小侠客模拟器
桌面小猫娘
最后的修仙者
イル・ドー
攻上凌霄宝殿
东方光耀夜 ~ Lost Branch of Legend
消失的航班，还有她她她！Lost in the secret!
咸鱼殿下
推币勇者
通神榜 Noobs Want to Live
俠之道(PathOfWuxia)
侠客风云传(Tale of Wuxia)
吞食孔明传 Tunshi Kongming Legends
修仙：但系统让我种田
天月麻雀
ラブライブ！虹ヶ咲学園スクールアイドル同好会　トキメキの未来地図
中华一商：传承
天命奇御二 Fate Seeker II
英雄伝説 創の軌跡
修仙立志传
懒人修仙传2
富甲天下5
海沙风云 Far Away
咸鱼的挂机游戏
挂机神话
江湖客栈-无尽轮回
降妖散记
飛天歷險國際中文版
山门与幻境（The Lost Village）
逐鹿
铁骑少女（Cavalry Girls）
再刷一把 PlayAgain
汉尘：腐草为萤
ホロライブお宝マウンテン
无罪之庭/Trials of Innocence
手办冒险团

