### PR TITLE
Add Stardew Valley modded for SMAPI user to linux-native_s.rules

### DIFF
--- a/00-default/Games/linux-native/linux-native_s.rules
+++ b/00-default/Games/linux-native/linux-native_s.rules
@@ -403,6 +403,7 @@
 
 # Stardew Valley https://store.steampowered.com/app/413150/Stardew_Valley/
 { "name": "Stardew Valley", "type": "Game" }
+{ "name": "StardewModdingAPI", "type": "Game" }
 
 # StarDrive 2 https://store.steampowered.com/app/252450/StarDrive_2/
 { "name": "SD2.x86_64", "type": "Game" }


### PR DESCRIPTION
I just realized when I looked at the btop and running process, it turned out that the name of the process changed after installing the patch from SMAPI. So instead of creating a new separate line, I added the process to the existing Stardew Valley line as a second process so that ananicy could automatically read which one was running.

The mod loader for Stardew Valley, SMAPI is an open-source project by Pathoschild. It used for installing mod like custom texture and sound. Compatible with GOG/Steam achievements and Linux/macOS/Windows, uninstall anytime, and there's a friendly community if user need help.

Official mod website _https://smapi.io_

<img width="1366" height="768" alt="Screenshot_20260531_111239" src="https://github.com/user-attachments/assets/04cc4744-0c53-4e9f-869d-85480c0bf454" />
<img width="1366" height="768" alt="Screenshot_20260531_111315" src="https://github.com/user-attachments/assets/03d06f53-c08b-43ea-814d-49366bed6f4e" />
