### PR TITLE
add file managers to plasma, gnome and xfce

### DIFF
--- a/00-default/DEs-and-WMs/cinnamon.rules
+++ b/00-default/DEs-and-WMs/cinnamon.rules
@@ -1,0 +1,2 @@
+# https://github.com/linuxmint/nemo
+{ "name": "nemo", "type": "LowLatency_RT" }

--- a/00-default/DEs-and-WMs/gnome.rules
+++ b/00-default/DEs-and-WMs/gnome.rules
@@ -88,7 +88,7 @@
 # mutter-x11-frames
 { "name": "mutter-x11-frames", "type": "LowLatency_RT" }
 
-# GNOME image viewer: https://wiki.gnome.org/Apps/EyeOfGnome/
+# GNOME image viewer: https://gitlab.gnome.org/GNOME/eog
 { "name": "eog", "type": "Image-View" }
 
 # GNOME file manager: https://gitlab.gnome.org/GNOME/nautilus

--- a/00-default/DEs-and-WMs/gnome.rules
+++ b/00-default/DEs-and-WMs/gnome.rules
@@ -90,3 +90,6 @@
 
 # GNOME image viewer: https://wiki.gnome.org/Apps/EyeOfGnome/
 { "name": "eog", "type": "Image-View" }
+
+# GNOME file manager: https://gitlab.gnome.org/GNOME/nautilus
+{ "name": "nautilus", "type": "LowLatency_RT" }

--- a/00-default/DEs-and-WMs/lxde.rules
+++ b/00-default/DEs-and-WMs/lxde.rules
@@ -1,0 +1,2 @@
+# https://github.com/lxde/pcmanfm
+{ "name": "pcmanfm", "type": "LowLatency_RT" }

--- a/00-default/DEs-and-WMs/lxqt.rules
+++ b/00-default/DEs-and-WMs/lxqt.rules
@@ -1,0 +1,2 @@
+# https://github.com/lxqt/pcmanfm-qt
+{ "name": "pcmanfm-qt", "type": "LowLatency_RT" }

--- a/00-default/DEs-and-WMs/plasma.rules
+++ b/00-default/DEs-and-WMs/plasma.rules
@@ -1,5 +1,7 @@
 # pnames started with `.` are NixOS specific
 
+# https://github.com/KDE/dolphin
+{ "name": "dolphin", "type": "LowLatency_RT" }
 # https://community.kde.org/Baloo
 # Baloo is the file indexing and file search framework for KDE.
 { "name": "baloo_file", "type": "BG_CPUIO" }

--- a/00-default/DEs-and-WMs/xfce4.rules
+++ b/00-default/DEs-and-WMs/xfce4.rules
@@ -1,3 +1,4 @@
+{ "name": "thunar", "type": "LowLatency_RT" }
 { "name": "xfwm4", "type": "LowLatency_RT" }
 { "name": "xfsettingsd", "type": "LowLatency_RT" }
 { "name": "xfce4-session", "type": "LowLatency_RT" }


### PR DESCRIPTION
as discussed in #482 , added file managers for 3 major DEs: plasma (dolphin), gnome (nautilus) and xfce (thunar).

for each of them set type to "LowLatency_RT", same level as for other core DE components. 

thanks!