### PR TITLE
Disabled buggy Helium rules

### DIFF
--- a/00-default/Browsers/browsers.rules
+++ b/00-default/Browsers/browsers.rules
@@ -28,8 +28,7 @@
 { "name": "cromite", "type": "Doc-View" }
 
 # Helium - https://helium.computer/
-{ "name": "helium", "type": "Doc-View" }
-{ "name": "helium_crashpad_handler", "type": "BG_CPUIO" }
+# Disabled for stability purposes
 
 # Opera - https://www.opera.com/
 { "name": "opera", "type": "Doc-View" }


### PR DESCRIPTION
There is an issue related to helium process getting all over the place, and I think the best solution is to disable helium optimizations till this gets fixed upstream.

<img width="1091" height="401" alt="image" src="https://github.com/user-attachments/assets/b5302080-5b42-43e6-84f6-fb66586c67c0" />

