### PR TITLE
Add patch for users who play Skyrim and Oblivion with SKSE/xOBSE loader

### DIFF
--- a/00-default/Games/wine_proton/common.rules
+++ b/00-default/Games/wine_proton/common.rules
@@ -2209,6 +2209,7 @@
 # The Elder Scrolls V: Skyrim https://store.steampowered.com/app/72850/The_Elder_Scrolls_V_Skyrim/
 # Enderal: Forgotten Stories (Special Edition) https://store.steampowered.com/app/976620/Enderal_Forgotten_Stories_Special_Edition/
 { "name": "SkyrimSE.exe", "type": "Game" }
+{ "name": "skse64_loader.exe", "type": "BG_CPUIO" }
 
 # Shin Megami Tensei V: Vengeance Demo https://store.steampowered.com/app/3185590/
 # Shin Megami Tensei V: Vengeance https://store.steampowered.com/app/1875830/Shin_Megami_Tensei_V_Vengeance/
@@ -2452,6 +2453,7 @@
 # The Elder Scrolls V: Skyrim https://store.steampowered.com/app/72850/The_Elder_Scrolls_V_Skyrim/
 # Enderal: Forgotten Stories https://store.steampowered.com/app/933480/Enderal_Forgotten_Stories/
 { "name": "TESV.exe", "type": "Game" }
+{ "name": "skse_loader.exe", "type": "BG_CPUIO" }
 
 # The First Million https://store.steampowered.com/app/4446010/The_First_Million/
 # The First Million Demo https://store.steampowered.com/app/4553590/The_First_Million_Demo/

--- a/00-default/Games/wine_proton/common.rules
+++ b/00-default/Games/wine_proton/common.rules
@@ -1741,6 +1741,7 @@
 # The Elder Scrolls IV: Oblivion Game of the Year Edition (2009) https://store.steampowered.com/app/22330/The_Elder_Scrolls_IV_Oblivion_Game_of_the_Year_Edition_2009/
 # The Elder Scrolls IV: Oblivion Game of the Year Edition Deluxe (2009) https://store.steampowered.com/app/900883/The_Elder_Scrolls_IV_Oblivion_Game_of_the_Year_Edition_Deluxe/
 { "name": "Oblivion.exe", "type": "Game" }
+{ "name": "obse_loader.exe", "type": "BG_CPUIO" }
 
 # The Elder Scrolls IV: Oblivion Game of the Year Edition (2009) https://store.steampowered.com/app/22330/The_Elder_Scrolls_IV_Oblivion_Game_of_the_Year_Edition_2009/
 # The Elder Scrolls IV: Oblivion Game of the Year Edition Deluxe (2009) https://store.steampowered.com/app/900883/The_Elder_Scrolls_IV_Oblivion_Game_of_the_Year_Edition_Deluxe/


### PR DESCRIPTION
SKSE or Skyrim Script Extender and xOBSE or Oblivion Script Extender is a mod script loader for enhancing the gameplay experience in Skyrim and Oblivion. It expands the game's scripting capabilities, allowing for external script from complex mods and add functionalities.