### PR TITLE
Added new rules for applications

### DIFF
--- a/00-default/Audio-Video/swayimg.rules
+++ b/00-default/Audio-Video/swayimg.rules
@@ -1,0 +1,2 @@
+# Swayimg https://github.com/artemsen/swayimg
+{ "name": "swayimg", "type": "Image-View" }

--- a/00-default/Browsers/browsers.rules
+++ b/00-default/Browsers/browsers.rules
@@ -4,6 +4,7 @@
 { "name": "brave", "type": "Doc-View" }
 { "name": "brave-bin", "type": "Doc-View" }
 { "name": "brave-browser", "type": "Doc-View" }
+{ "name": "brave-origin", "type": "Doc-View" }
 { "name": "brave-sandbox", "type": "Doc-View" }
 
 # Chrome - https://www.google.com/chrome/

--- a/00-default/Chats/chats.rules
+++ b/00-default/Chats/chats.rules
@@ -1,13 +1,13 @@
-# Zoom - https://zoom.us
+# Zoom: https://zoom.us
 { "name": "zoom", "type": "Chat" }
 
 # weechat: https://weechat.org/
 { "name": "weechat", "type": "Chat" }
 
-# https://www.viber.com
+# Viber: https://www.viber.com
 { "name": "viber", "type": "Chat" }
 
-# https://desktop.telegram.org/
+# Telegram: https://desktop.telegram.org/
 { "name": "Telegram", "type": "Chat" }
 { "name": "telegram-desktop", "type": "Chat" }
 { "name": "telegram-desktop.bin", "type": "Chat" }
@@ -31,7 +31,7 @@
 { "name": "fluxer_desktop", "type": "Chat" }
 { "name": "fluxer-canary", "type": "Chat" }
 
-# https://hexchat.github.io
+# Hexchat: https://hexchat.github.io
 { "name": "hexchat", "type": "Chat" }
 
 # Teams: https://teams.microsoft.com/downloadsallDevicesSection
@@ -42,10 +42,13 @@
 # 64gram: https://64gr.am/
 { "name": "64gram-desktop", "type": "Chat" }
 
-# https://archlinux.org/packages/extra/x86_64/gurk/
+# AyuGram: https://github.com/AyuGram/AyuGramDesktop
+{ "name": "AyuGram", "type": "Chat" }
+
+# Gurk: https://archlinux.org/packages/extra/x86_64/gurk/
 { "name": "gurk", "type": "Chat" }
 
-# http://vk.com/messenger
+# Vk: http://vk.com/messenger
 { "name": "caprine", "type": "Chat" }
 { "name": "qtox", "type": "Chat" }
 { "name": "rambox", "type": "Chat" }
@@ -56,10 +59,10 @@
 { "name": "vk", "type": "Chat" }
 { "name": "mailspring", "type": "Chat" }
 
-# https://www.mozilla.org/en-US/thunderbird/
+# Thunderbird: https://www.mozilla.org/en-US/thunderbird/
 { "name": "thunderbird", "type": "Chat" }
 
-# https://github.com/Betterbird/thunderbird-patches
+# Betterbird: https://github.com/Betterbird/thunderbird-patches
 { "name": "betterbird", "type": "Chat" }
 { "name": "betterbird-bin", "type": "Chat" }
 

--- a/00-default/DEs-and-WMs/noctalia.rules
+++ b/00-default/DEs-and-WMs/noctalia.rules
@@ -1,0 +1,2 @@
+# Noctalia https://github.com/noctalia-dev/noctalia
+{ "name": "noctalia", "type": "Service" }

--- a/00-default/Games/launchers.rules
+++ b/00-default/Games/launchers.rules
@@ -60,6 +60,9 @@
 # https://github.com/ElyPrismLauncher/ElyPrismLauncher
 { "name": "elyprismlauncher", "type": "Game" }
 
+# Modrinth App for launching minecraft (https://github.com/modrinth/code)
+{ "name": "modrinth", "type": "Game" }
+
 # Fjord Launcher https://github.com/unmojang/FjordLauncher
 { "name": "fjordlauncher", "type": "Game" }
 

--- a/00-default/Games/launchers.rules
+++ b/00-default/Games/launchers.rules
@@ -66,6 +66,9 @@
 # Fjord Launcher https://github.com/unmojang/FjordLauncher
 { "name": "fjordlauncher", "type": "Game" }
 
+# Bottles https://github.com/bottlesdevs/bottles
+{ "name": "bottles", "type": "BG_CPUIO" } 
+
 # integrated web engine
 { "name": "QtWebEngineProcess.exe", "type": "BG_CPUIO" }
 

--- a/00-default/Games/wine_proton/wine_proton_g.rules
+++ b/00-default/Games/wine_proton/wine_proton_g.rules
@@ -487,6 +487,10 @@
 { "name": "MZGame.exe", "type": "BG_CPUIO" }
 { "name": "MZGame-Win64-Shipping.exe", "type": "Game" }
 
+# GODDESS OF VICTORY: NIKKE https://nikke-en.com/
+{ "name": "nikke_launcher.exe", "type": "BG_CPUIO" }
+{ "name": "nikke.exe", "type": "Game" }
+
 # Godsbane Idle https://store.steampowered.com/app/1565140/Godsbane_Idle/
 { "name": "Godsbane.exe", "type": "Game" }
 

--- a/00-default/VPN/amneziavpn.rules
+++ b/00-default/VPN/amneziavpn.rules
@@ -1,0 +1,2 @@
+# Amnezia - Qt VPN client (https://github.com/amnezia-vpn/amnezia-client)
+{ "name": "AmneziaVPN", "type": "IN_DIFF" }


### PR DESCRIPTION
added modrinth, bottles, Nikke, amneziavpn, Noctalia, and Swayimg rules.

I am not quite sure how to configure rules for Prism Launcher and Modrinth. My main concern is that if I create a rule targeting "java," it will globally affect all Java instances running on the system. However, when I look at the main process for both launchers, I find that they are named neither "prismlauncher" nor "modrinth." The processes are called "prismrun" and "modrinth-app-wrapped", so I am a little confused.