### PR TITLE
Add World of Warcraft Classic

### DIFF
--- a/00-default/Games/wine_proton/wine_proton_w.rules
+++ b/00-default/Games/wine_proton/wine_proton_w.rules
@@ -967,8 +967,9 @@
 # World of Tanks: HEAT https://store.steampowered.com/app/2100280/World_of_Tanks_HEAT/
 { "name": "wgcs_api.exe", "type": "Game" }
 
-# World of Warcraft https://worldofwarcraft.blizzard.com/en-us/
+# World of Warcraft & World of Warcraft Classic https://worldofwarcraft.blizzard.com/en-us/
 { "name": "Wow.exe", "type": "Game" }
+{ "name": "WowClassic.exe", "type": "Game" }
 
 # World of Warplanes https://store.steampowered.com/app/790710/World_of_Warplanes/
 { "name": "WorldOfWarplanes.exe", "type": "Game" }


### PR DESCRIPTION
The World of Warcraft Classic executable was missing, so I added it.
If you would like it as separate entry, let me know and I'll change it.

Also the Github web editor does something weird to the end of file. If that is a problem let me know too.