### PR TITLE
Avoid idle scheduling for Steam

### DIFF
--- a/00-default/Games/launchers.rules
+++ b/00-default/Games/launchers.rules
@@ -74,15 +74,15 @@
 
 # Rules for Steam
 # Steam client
-{ "name": "steam", "type": "BG_CPUIO" }
-{ "name": "steam.sh", "type": "BG_CPUIO" }
+{ "name": "steam", "type": "BG_CPUIO", "sched": "normal" }
+{ "name": "steam.sh", "type": "BG_CPUIO", "sched": "normal" }
 
 # Steam integrated web browser
 { "name": "steamwebhelper", "type": "Doc-View" }
 
 # Rules for Steam on Wine
 # Steam client
-{ "name": "Steam.exe", "type": "BG_CPUIO" }
+{ "name": "Steam.exe", "type": "BG_CPUIO", "sched": "normal" }
 
 # SteamVR
 { "name": "vrserver", "type": "LowLatency_RT" }

--- a/00-default/Games/launchers.rules
+++ b/00-default/Games/launchers.rules
@@ -74,15 +74,15 @@
 
 # Rules for Steam
 # Steam client
-{ "name": "steam", "type": "BG_CPUIO", "sched": "normal" }
-{ "name": "steam.sh", "type": "BG_CPUIO", "sched": "normal" }
+{ "name": "steam", "type": "Launcher" }
+{ "name": "steam.sh", "type": "Launcher" }
 
 # Steam integrated web browser
 { "name": "steamwebhelper", "type": "Doc-View" }
 
 # Rules for Steam on Wine
 # Steam client
-{ "name": "Steam.exe", "type": "BG_CPUIO", "sched": "normal" }
+{ "name": "Steam.exe", "type": "Launcher" }
 
 # SteamVR
 { "name": "vrserver", "type": "LowLatency_RT" }

--- a/00-types.types
+++ b/00-types.types
@@ -21,6 +21,10 @@
 # Background CPU/IO it's needed, but it must be as silent as possible
 { "type": "BG_CPUIO", "nice": 16, "ioclass": "idle", "sched": "idle" }
 
+# Type: Background Launcher
+# Runs quietly but may spawn foreground or latency-sensitive workloads
+{ "type": "Launcher", "nice": 16, "ioclass": "idle", "sched": "normal" }
+
 # Type: Background CPU but demands more I/O, One example: File Synchronization
 { "type": "BG_CPU", "nice": 14, "ioclass": "best-effort", "sched": "idle" }
 


### PR DESCRIPTION
Steam launches games through descendant processes, which inherit the client's CPU scheduler policy. When Steam uses `SCHED_IDLE`, latency-sensitive game workers can retain that policy even after the game itself is matched by an Ananicy rule.

I ran into this with CS2: the game leader was `SCHED_OTHER`, while several SDL and PipeWire audio workers remained `SCHED_IDLE` and accumulated xruns under load.

Solution is to keep Steam's existing background nice and I/O settings, but explicitly use the normal CPU scheduler for the native and Wine Steam client rules.

PR #573 added `sched: normal` to the `Game` type, which restores `SCHED_OTHER` for a matched game's process leader. However, Ananicy-Cpp's scheduler setter calls `sched_setscheduler()` only for the matched PID, it does not iterate over every thread in `/proc/<pid>/task` as its nice-priority setter does.

Because scheduling policy is per-thread, workers created before the game rule is applied-or later created by an idle-scheduled worker can remain `SCHED_IDLE`. This was the CS2 state I ran into: the process leader was `SCHED_OTHER`, while several SDL and PipeWire audio workers were still `SCHED_IDLE`.

Explicitly keeping Steam under the normal scheduler prevents the unwanted policy from being inherited at the source, while retaining its background nice and I/O priorities.

#### Validation:
`ananicy-cpp dump rules` successfully loaded the modified rules, and all three Steam entries resolved to nice 16, idle I/O, and normal CPU scheduling.

Fixes #569.
