### PR TITLE
Add dmemcg-booster, kde/niri boosters and mpd-mpris rule

### DIFF
--- a/00-default/Audio-Video/mpd.rules
+++ b/00-default/Audio-Video/mpd.rules
@@ -1,2 +1,4 @@
 # Music player: https://www.musicpd.org/
 { "name": "mpd", "type": "Player-Audio" }
+
+{ "name": "mpd-mpris", "type": "Service" }

--- a/00-default/Services/dmemcg-booster.rules
+++ b/00-default/Services/dmemcg-booster.rules
@@ -1,4 +1,6 @@
 { "name": "dmemcg-booster", "type": "Service" }
 
+# KDE Booster
+{ "name": "foreground_booster", "type": "Service" }
+# Niri Booster
 { "name": "niri-focused-booster", "type": "Service" }
-{ "name": "plasma-foreground-booster-dmemcg", "type": "Service" }

--- a/00-default/Services/dmemcg-booster.rules
+++ b/00-default/Services/dmemcg-booster.rules
@@ -1,0 +1,4 @@
+{ "name": "dmemcg-booster", "type": "Service" }
+
+{ "name": "niri-focused-booster", "type": "Service" }
+{ "name": "plasma-foreground-booster-dmemcg", "type": "Service" }


### PR DESCRIPTION
**Changes:**
- Added `dmemcg-booster` and `mpd-mpris` services

Note: `dmemcg-booster` requires further testing to confirm long-term stability.