### PR TITLE
Add Benchmark and stress test rules file to tools 

### DIFF
--- a/00-default/Tools/Stress&Benchmark.rules
+++ b/00-default/Tools/Stress&Benchmark.rules
@@ -1,11 +1,11 @@
-# S-Tui https://github.com/amanusk/s-tui
-{ "name": "s-tui", "type": "Game" }
-
 # GeekBench https://www.geekbench.com/
 { "name": "geekbench_avx2", "type": "Game" }
 { "name": "geekbench_x86_64", "type": "Game" }
 { "name": "geekbench7", "type": "BG_CPUIO" }
 { "name": "geekbench6", "type": "BG_CPUIO" }
+
+# S-Tui https://github.com/amanusk/s-tui
+{ "name": "s-tui", "type": "Game" }
 
 # Unigine Benchmarks https://benchmark.unigine.com/
 # Superposition

--- a/00-default/Tools/Stress&Benchmark.rules
+++ b/00-default/Tools/Stress&Benchmark.rules
@@ -1,0 +1,12 @@
+# S-Tui https://github.com/amanusk/s-tui
+{ "name": "s-tui", "type": "Game" }
+
+# GeekBench https://www.geekbench.com/
+{ "name": "geekbench_avx2", "type": "Game" }
+{ "name": "geekbench_x86_64", "type": "Game" }
+{ "name": "geekbench7", "type": "BG_CPUIO" }
+{ "name": "geekbench6", "type": "BG_CPUIO" }
+
+# Unigine Benchmarks https://benchmark.unigine.com/
+# Superposition
+{ "name": "superposition", "type": "Game" }


### PR DESCRIPTION
none of these were already in files but also didnt cleanly fit into any, so i opted to put a new file just for benchmarks and stress tests in the tools folder, to keep them more organized.