### PR TITLE
fix: keep ly session launcher out of idle scheduler

### DIFF
--- a/00-default/DEs-and-WMs/ly.rules
+++ b/00-default/DEs-and-WMs/ly.rules
@@ -1,2 +1,2 @@
 # ly, a TUI lightweight display manager: https://github.com/fairyglade/ly
-{ "name": "ly-dm", "type": "BG_CPUIO" }
+{ "name": "ly-dm", "type": "Launcher" }


### PR DESCRIPTION
Fixes #596

`BG_CPUIO` assigns `ly-dm` the `SCHED_IDLE` policy, which is inherited by descendants of the session launcher. Later rules that adjust nice or I/O priority do not necessarily reset the inherited scheduler policy.

Use the established `Launcher` type instead: it retains the intended background nice/IO behavior while explicitly restoring the normal scheduler policy. This follows the accepted #586/#587 session-manager precedent.

The change is intentionally limited to `ly-dm`; `lxdm` and `gdm` entries were not changed because this issue did not empirically establish the same runtime topology for them. Validation included rule parsing/dump resolution, inheritance checks, and `git diff --check`.