### PR TITLE
chore: add lint.py script and JSONSchema for rules and cgroups definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+install:
+	cp -R *.cgroups *.types ananicy.conf 00-default /etc/ananicy.d/
+lint:
+	python lint.py

--- a/README.md
+++ b/README.md
@@ -1,27 +1,40 @@
 # Ananicy-cpp-rules for CachyOS
+
 This is a ananicy-cpp-rules collection for ananicy-cpp maintained by the CachyOS team and the community.
 
 ## Ananicy-cpp & ananicy-cpp-rules
+
 - **[ananicy-cpp](https://gitlab.com/ananicy-cpp/ananicy-cpp)** - daemon that automatically adjusts the nice levels of processes.
 - **ananicy-cpp-rules** - list of rules used to assign specific nice values to specific processes.
+
 > The nice value determines the priority of a process, with higher values indicating lower priority and making the process "nicer" to other processes. By default, on Linux workstations, the nice value is set to 0.
+
+## Installation
+
+```sh
+sudo make install
+```
+
+This script will copy all the rules from this repo to `/etc/ananicy.d` dir.
 
 ## How to contribute
 
-You can add your favorite games, apps, and more. Any help would be greatly appreciated!  
+You can add your favorite games, apps, and more. Any help would be greatly appreciated!
 **For example, let's say you want to add a game:**
+
 1. Go to [00-default](https://github.com/CachyOS/ananicy-rules/tree/master/00-default)
 2. Go to [Games](https://github.com/CachyOS/ananicy-rules/tree/master/00-default/Games)
 3. Navigate to the desired folder depending on:
-	- Game is meant to be ran under with Proton: [`wine_proton`](https://github.com/CachyOS/ananicy-rules/tree/master/00-default/Games/wine_proton) - *Open the corresponding file depending on the letter.*
-	- Provides a native version for Linux: [`linux-native`](https://github.com/CachyOS/ananicy-rules/tree/master/00-default/Games/linux-native) - *Open the corresponding file depending on the letter.*
+	- Game is meant to be ran under with Proton: [`wine_proton`](https://github.com/CachyOS/ananicy-rules/tree/master/00-default/Games/wine_proton) → *Open the corresponding file depending on the letter.*
+	- Provides a native version for Linux: [`linux-native`](https://github.com/CachyOS/ananicy-rules/tree/master/00-default/Games/linux-native) → *Open the corresponding file depending on the letter.*
 4. Open the corresponding file depending on the letter.
 5. Follow the examples from below.
 
 ### Examples of rules
+
 The **first example** is simple. In the **second example**, it is different because some games generate multiple processes. In such cases, you need to add all the processes related to the game.
 
-Please also add the name of the game next to the url, which you get the name of said game from the Steam store. 
+Please also add the name of the game next to the url, which you get the name of said game from the Steam store.
 
 If not from any store add name you think it needs.
 
@@ -47,23 +60,35 @@ If not from any store add name you think it needs.
 { "name": "portal2_linux", "type": "Game" }
 ```
 
-Duplicate entries can be detected with this command: ```grep -rhoP --include='*.rules' '"name"\s*:\s*"\K[^"]+' . | sort | uniq -d```
-
-Games can be sorted with sort-games.sh, for more information run this in terminal ```./sort-games.sh --help```
-
-Rules can be linted against JSONSchema with `lint.py` script. It reqires `python-fastjsonschema` to be installed, then it can be run with `python lint.py`. No output means everything is fine.
-
 ### <u>You can also contribute by opening an [issue](https://github.com/CachyOS/ananicy-rules/issues) and providing information about the application </u>
+
 **Make sure the app is not already in the repository before opening an issue.**
+
+### Linting
+
+```sh
+make lint
+```
+
+This will check rules syntax and also check for duplicates. Script requires Python and [python-fastjsonschema](https://horejsek.github.io/python-fastjsonschema/) to be available.
+
+Games can be sorted with `sort-games.sh`, for more information run this in terminal: `./sort-games.sh --help`
+
 ## How to find out proper process name?
+
 Here is a list of tools
+
 ### CLI
+
 - [htop](https://htop.dev/)
 - [btop](https://github.com/aristocratos/btop)
+
 ### GUI
+
 - System Monitor [KDE Plasma](https://apps.kde.org/plasma-systemmonitor/) or [GNOME](https://help.gnome.org/users/gnome-system-monitor/)
 
 **Don't use absolute paths for the executables. Process name alone is enough.**
 
 ## [GameMode](https://github.com/FeralInteractive/gamemode) + [ananicy-cpp](https://gitlab.com/ananicy-cpp/ananicy-cpp) = bad idea
+
 GameMode and ananicy-cpp both adjust the nice levels of processes. However, combining both tools is not recommended, and we strongly advise against doing so.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Duplicate entries can be detected with this command: ```grep -rhoP --include='*.
 
 Games can be sorted with sort-games.sh, for more information run this in terminal ```./sort-games.sh --help```
 
+Rules can be linted against JSONSchema with `lint.py` script. It reqires `python-fastjsonschema` to be installed, then it can be run with `python lint.py`. No output means everything is fine.
+
 ### <u>You can also contribute by opening an [issue](https://github.com/CachyOS/ananicy-rules/issues) and providing information about the application </u>
 **Make sure the app is not already in the repository before opening an issue.**
 ## How to find out proper process name?

--- a/ananicy-cgroups.schema.json
+++ b/ananicy-cgroups.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Ananicy cgroups definition",
+  "description": "Schema for Ananicy cgroups files.",
+  "type": "object",
+  "required": [
+    "cgroup"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "cgroup": {
+      "type": "string",
+      "description": "cgroup name"
+    },
+    "CPUQuota": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/ananicy.schema.json
+++ b/ananicy.schema.json
@@ -1,14 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Ananicy Rule",
-  "description": "Schema for Ananicy rule files.",
+  "title": "Ananicy Type",
+  "description": "Schema for Ananicy type files.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "name": {
-      "type": "string",
-      "description": "Name of the process"
-    },
     "nice": {
       "type": "integer",
       "minimum": -20,

--- a/ananicy.schema.json
+++ b/ananicy.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Ananicy Rule",
+  "description": "Schema for Ananicy rule files.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the process"
+    },
+    "nice": {
+      "type": "integer",
+      "minimum": -20,
+      "maximum": 19,
+      "description": "nice level"
+    },
+    "latency_nice": {
+      "type": "integer",
+      "minimum": -20,
+      "maximum": 19,
+      "description": "latency_nice level"
+    },
+    "ionice": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 7,
+      "description": "ionice level"
+    },
+    "sched": {
+      "type": "string",
+      "description": "Scheduling policy",
+      "enum": [
+        "fifo",
+        "rr",
+        "normal",
+        "batch",
+        "idle"
+      ]
+    },
+    "rtprio": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 99,
+      "description": "Static priority of a process. Only relevant if the actual scheduling policy of a process is a realtime one, i.e. fifo, rr or deadline."
+    },
+    "ioclass": {
+      "type": "string",
+      "enum": [
+        "best-effort",
+        "realtime",
+        "idle",
+        "none"
+      ],
+      "description": "Define the IO scheduling policy."
+    },
+    "oom_score_adj": {
+      "type": "integer",
+      "minimum": -1000,
+      "maximum": 1000,
+      "description": "Adjust the Out Of Memory killer score of  a process. Negative value decrease the score of the process, making it less likely to be killed if available memory gets very low."
+    },
+    "cpuset": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "big-cores",
+            "little-cores",
+            "turbo-cores",
+            "performance-cores",
+            "efficiency-cores",
+            "all-cores",
+            "x3d-cache",
+            "x3d-frequency"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d+-\\d+$",
+          "examples": ["0-7"]
+        },
+        {
+          "type": "string",
+          "pattern": "^(\\d+(-\\d+)?)[^,]?+$",
+          "examples": ["0,2,4", "0-3,8-11"]
+        },
+        {
+          "type": "string",
+          "pattern": "^(llc|node)-[\\d]+$",
+          "examples": ["llc-1", "node-0"]
+        }
+       ],
+       "description": "Pin the process to the specified CPU cores using Linux cpuset notation."
+    },
+    "cgroup": {
+      "type": "string",
+      "description": "Put the process in the specified cgroup. This can be any cgroup, including those created outside ananicy-cpp."
+    },
+    "type": {
+      "type": "string",
+      "description": "Set the type of the rule. All options defined in the type will be used as if written explicitly in the rule, although you can override each option if needed."
+    }
+  }
+}

--- a/lint.py
+++ b/lint.py
@@ -2,41 +2,66 @@ import fileinput
 import json
 from pathlib import Path
 import fastjsonschema
+import sys
+
+types = set()
+names = dict()
+errors = list()
 
 def iterate_files(files, validator):
     with fileinput.input(files=files, encoding="utf-8") as f:
         for ln, line in enumerate(f):
-            result = validate_line(line, validator)
-            if result is not True:
-                print("Error in file {filename} on line {ln}"
-                    .format(ln=ln, filename=f.filename()))
-                print("Line: %s" % line)
-                print("Error: %s" % result)
+            try:
+                validate_line(line, validator, f.filename())
+            except ValueError as e:
+                errors.append({
+                    'filename': f.filename(),
+                    'ln': ln,
+                    'line': line.rstrip(),
+                    'message': e
+                })
 
-
-def validate_line(line, validator):
+def validate_line(line, validator, filename):
     if line.startswith('#') or line.strip() == "":
         return True
     try:
         record = json.loads(line)
         validator(record)
+        if filename.suffix == '.types':
+            types.add(record['type'])
+        elif filename.suffix == '.rules':
+            if 'type' in record and record['type'] not in types:
+                raise ValueError(f'Invalid type: {record['type']}')
+            if 'name' in record and record['name'] in names:
+                raise ValueError(f'Duplicate name: {record['name']}, present also in {names[record['name']]}')
+            names[record['name']] = filename
     except json.JSONDecodeError as e:
-        return f'Invalid JSON: {e.msg}'
+        raise ValueError(f'Invalid JSON: {e.msg}')
     except fastjsonschema.JsonSchemaException as e:
-        return e.message
+        raise ValueError(e.message)
     return True
 
-with open('ananicy-cgroups.schema.json', 'r') as cgroups_schema_file:
-    cgroups_schema = json.load(cgroups_schema_file)
-    cgroups_validator = fastjsonschema.compile(cgroups_schema)
-    exts = [".cgroups"]
-    files = list([p for p in Path('.').rglob('*') if p.suffix in exts])
-    iterate_files(files, cgroups_validator)
+def validate_with_schema(schema_file, glob):
+    with Path(schema_file).resolve().open('r', encoding="utf-8") as f:
+        schema = json.load(f)
+        if glob == "*.rules":
+            schema['required'] = ["name"]
+            schema["properties"]["name"] = {
+                "type": "string",
+                "description": "Name of the process"
+            }
+        validator = fastjsonschema.compile(schema)
+        files = list(Path('.').rglob(glob))
+        iterate_files(files, validator)
 
-with open('ananicy.schema.json', 'r') as rule_schema_file:
-    rule_schema = json.load(rule_schema_file)
-    rule_validator = fastjsonschema.compile(rule_schema)
-    exts = [".rules", ".types"]
-    files = list([p for p in Path('.').rglob('*') if p.suffix in exts])
-    iterate_files(files, rule_validator)
+validate_with_schema('ananicy-cgroups.schema.json', '*.cgroups')
+validate_with_schema('ananicy.schema.json', '*.types')
+validate_with_schema('ananicy.schema.json', '*.rules')
 
+if len(errors) > 0:
+    for error in errors:
+        print(f"""Error in file {error['filename']} on line {error['ln']}
+Line: {error['line']}
+{error['message']}
+""")
+    sys.exit(1)

--- a/lint.py
+++ b/lint.py
@@ -1,0 +1,42 @@
+import fileinput
+import json
+from pathlib import Path
+import fastjsonschema
+
+def iterate_files(files, validator):
+    with fileinput.input(files=files, encoding="utf-8") as f:
+        for ln, line in enumerate(f):
+            result = validate_line(line, validator)
+            if result is not True:
+                print("Error in file {filename} on line {ln}"
+                    .format(ln=ln, filename=f.filename()))
+                print("Line: %s" % line)
+                print("Error: %s" % result)
+
+
+def validate_line(line, validator):
+    if line.startswith('#') or line.strip() == "":
+        return True
+    try:
+        record = json.loads(line)
+        validator(record)
+    except json.JSONDecodeError as e:
+        return f'Invalid JSON: {e.msg}'
+    except fastjsonschema.JsonSchemaException as e:
+        return e.message
+    return True
+
+with open('ananicy-cgroups.schema.json', 'r') as cgroups_schema_file:
+    cgroups_schema = json.load(cgroups_schema_file)
+    cgroups_validator = fastjsonschema.compile(cgroups_schema)
+    exts = [".cgroups"]
+    files = list([p for p in Path('.').rglob('*') if p.suffix in exts])
+    iterate_files(files, cgroups_validator)
+
+with open('ananicy.schema.json', 'r') as rule_schema_file:
+    rule_schema = json.load(rule_schema_file)
+    rule_validator = fastjsonschema.compile(rule_schema)
+    exts = [".rules", ".types"]
+    files = list([p for p in Path('.').rglob('*') if p.suffix in exts])
+    iterate_files(files, rule_validator)
+


### PR DESCRIPTION
It's a real pain to maintain such large collection of rules, so I propose a simple python script which at least would validate that rules files are valid against json schema. There is some room to improvement, ideally it should also check that referenced types in rules is present in `.types` files and integrated into CI/pre-commit hook, but as is it's already useful.