### PR TITLE
ananicy: add Portal Alive & Kicking

### DIFF
--- a/00-default/Games/wine_proton/wine_proton_p.rules
+++ b/00-default/Games/wine_proton/wine_proton_p.rules
@@ -1005,6 +1005,9 @@
 # Portal 2: Community Edition https://store.steampowered.com/app/440000/Portal_2_Community_Edition/
 { "name": "p2ce.exe", "type": "Game" }
 
+# Portal: Alive & Kicking https://store.steampowered.com/app/270470/Portal_Alive__Kicking/
+{ "name": "aak.exe", "type": "Game" }
+
 # Portal Dungeon https://store.steampowered.com/app/1679220/Portal_Dungeon/
 { "name": "Portal Dungeon.exe", "type": "Game" }
 


### PR DESCRIPTION
Adds an Ananicy rule for Portal: Alive & Kicking.

The game runs through Proton as `aak.exe`, so this adds it to the existing
`wine_proton` game rules using the standard `Game` profile.

Fixes #601

Validation:
- rule JSON parsing
- duplicate process-name check
- `git diff --check`